### PR TITLE
Update yform.php

### DIFF
--- a/lib/yform.php
+++ b/lib/yform.php
@@ -187,6 +187,7 @@ class rex_yform
 
     public function getForm()
     {
+        rex_extension::registerPoint(new rex_extension_point('YFORM_GENERATE',$this));
         $this->executeFields();
         return $this->executeActions();
     }


### PR DESCRIPTION
Einfach damit man YForm erweitern kann. Das scheint mir enorm wichtig, wenn so viel mit YForm umgesetzt wird.

In der `boot.php` kann dass dan wie folgt aussehen:

```
rex_extension::register('YFORM_GENERATE',function($ep) {
  if(strpos(rex_get('page'),'content') !== false) {
    $YForm = $ep->getSubject();
    $YForm->setValueField('text', ['ein_feld', 'Label']);
  }
});
```