### PR TITLE
Radio klasse analog zum Checkbox-Template ergänzen

### DIFF
--- a/ytemplates/bootstrap/value.radio.tpl.php
+++ b/ytemplates/bootstrap/value.radio.tpl.php
@@ -34,7 +34,7 @@ if (trim($this->getElement('grid')) != '') {
 
 
 <?php if (trim($this->getLabel()) != ''): ?>
-    <div class="form-group">
+    <div class="radio form-group">
     <label class="control-label<?php echo $class_label; ?>"><?php echo $this->getLabel() ?></label>
 <?php endif; ?>
 <?php echo $field_before; ?>


### PR DESCRIPTION
Damit man hier leichter arbeiten kann, sollte die Klasse radio zum Element hinzugefügt werden.

Ich würde hier noch ein SPAN-Tag vor das Label stellen, damit man mit input:checked + span {} den Radiobutton anderst stylen kann.