### PR TITLE
Suchfunktion in Manager-Tabellen

### DIFF
--- a/plugins/manager/lib/yform/manager/search.php
+++ b/plugins/manager/lib/yform/manager/search.php
@@ -72,8 +72,8 @@ class rex_yform_manager_search
 
             if ($field->getTypeName() && $field->getType() == 'value' && $field->isSearchable()) {
 
-                if (method_exists('rex_yform_' . $field->getTypeName(), 'getSearchField')) {
-                    call_user_func('rex_yform_' . $field->getTypeName() . '::getSearchField', array(
+                if (method_exists('rex_yform_value_' . $field->getTypeName(), 'getSearchField')) {
+                    call_user_func('rex_yform_value_' . $field->getTypeName() . '::getSearchField', array(
                         'searchForm' => $yform,
                         'searchObject' => $this,
                         'field' => $field,
@@ -115,9 +115,9 @@ class rex_yform_manager_search
         foreach ($this->table->getFields() as $field) {
 
             if (array_key_exists($field->getName(), $vars['rex_yform_searchvars']) && $field->getType() == 'value' && $field->isSearchable()) {
-                rex_yform::includeClass($field->getType(), $field->getTypeName());
-                if (method_exists('rex_yform_' . $field->getTypeName(), 'getSearchFilter')) {
-                    $qf = call_user_func('rex_yform_' . $field->getTypeName() . '::getSearchFilter',
+//                rex_yform::includeClass($field->getType(), $field->getTypeName());
+                if (method_exists('rex_yform_value_' . $field->getTypeName(), 'getSearchFilter')) {
+                    $qf = call_user_func('rex_yform_value_' . $field->getTypeName() . '::getSearchFilter',
                         array(
                             'field' => $field,
                             'fields' => $this->table->getFields(),


### PR DESCRIPTION
Ich bin vor ein paar Tagen auf das Problem gestoßen, dass die Suche nicht geht und musste eine schnelle Lösung finden.
Dann habe ich gesehen, dass es dabei nur um ein paar Klassennamen geht, die falsch benannt sind, danach ging es schon.

Was ich auch gesehen habe: Es gibt zu dem Problem hier auch schon länger eine Bug-Meldung: #31  
