### PR TITLE
Leere Felder erlauben

### DIFF
--- a/lib/yform/validate/unique.inc.php
+++ b/lib/yform/validate/unique.inc.php
@@ -29,7 +29,7 @@ class rex_yform_validate_unique extends rex_yform_validate_abstract
                     if (is_array($value)) {
                         $value = implode(',', $value);
                     }
-                    $qfields[$Object->getId()] = '`' . $Object->getName() . '`=' . $cd->escape($value) . '';
+                    $qfields[$Object->getId()] = '`' . $Object->getName() . '`=' . $cd->escape($value) . ' AND ' . $cd->escape($value) . '!=""';
                 }
             }
 


### PR DESCRIPTION
Die validate-Klasse unique wirft einen Fehler, wenn das Feld leer ist (und auch sein darf).
Mit dieser Änderung dürfen mit unique validierte Felder auch leer bleiben.
Um die alte Funktionalität herzustellen, muss man einfach noch mit empty validieren.