### PR TITLE
default form_skin auf "bootstrap" ändern

### DIFF
--- a/plugins/manager/lib/yform/manager.php
+++ b/plugins/manager/lib/yform/manager.php
@@ -1327,7 +1327,7 @@ class rex_yform_manager
 
             $notation_php_pre = array(
             '$yform = new rex_yform();',
-            '$yform->setObjectparams(\'form_skin\', \'default\');',
+            '$yform->setObjectparams(\'form_skin\', \'bootstrap\');',
             '$yform->setObjectparams(\'form_showformafterupdate\', 0);',
             '$yform->setObjectparams(\'real_field_names\', true);',
             );


### PR DESCRIPTION
Wirft einen Fehler, wenn man den Formular-Code mit "default" als form_skin kopiert. Grund:
"default"-Template gibt's nicht mehr, ist jetzt "bootstrap".