### PR TITLE
im Dialog "Feld hinzufügen" <th> zu <td> geändert

### DIFF
--- a/lib/yform.php
+++ b/lib/yform.php
@@ -553,7 +553,7 @@ class rex_yform
                             $definitions = $class->getDefinitions();
                             $desc = isset($definitions['description']) ? $definitions['description'] : '';
                         }
-                        $classesDescription[ $arr_key ] .= '<tr><th><span class="btn btn-default btn-block"><code>' . $name . '</code></span></th><td class="vertical-middle">' . $desc . '</td></tr>';
+                        $classesDescription[ $arr_key ] .= '<tr><td><span class="btn btn-default btn-block"><code>' . $name . '</code></span></td><td class="vertical-middle">' . $desc . '</td></tr>';
                     }
                 }
             }


### PR DESCRIPTION
Durch <th> wurde der Button zum hinzufügen eines Feldtyps in der mobilen Ansicht ausgeblendet.
https://github.com/yakamara/redaxo_yform/issues/74