### PR TITLE
ID des geänderten Datensatzes bei Update abfragen

### DIFF
--- a/lib/yform/action/db.php
+++ b/lib/yform/action/db.php
@@ -52,6 +52,12 @@ class rex_yform_action_db extends rex_yform_action_abstract
                 $sql->setWhere($where);
                 $saved = $sql->update();
                 $action = 'update';
+
+                $sql_id = rex_sql::factory();
+                $sql_id->setTable($main_table);
+                $sql_id->setWhere($where);
+                $sql_id->select('id');
+                $this->params['main_id'] = $id = $this->params['value_pool']['email']['ID'] = $sql_id->getValue('id');
             } else {
                 $saved = $sql->insert();
                 $action = 'insert';


### PR DESCRIPTION
Bei installiertem Manager bekommt man die Fehlermeldung "$id has to be an integer greater than 0, but "-1" given'", wenn man mittels der db-Action versucht, einen Datensatz zu aktualisieren.
Ich weiß nicht genau, warum in der boot.php vom Manager-Plugin das Dataset abgefragt wird. Evtl. könnte man auch dort einfach das Dataset nur dann beziehen, wenn "hasHistory()" wahr ist.