### PR TITLE
E-Mail-Templates: "Absender" statt "E-Mail"

### DIFF
--- a/plugins/email/lang/de_de.lang
+++ b/plugins/email/lang/de_de.lang
@@ -1,6 +1,6 @@
 yform_email_templates = E-Mail Templates
 
-yform_email_key = Key - bitte nicht veraendern
+yform_email_key = Key - bitte nicht verändern
 yform_email_from = Absender-E-Mail [z.b.info@redaxo.de]
 yform_email_from_name = Absender-Name [z.b. REDAXO Server]
 yform_email_subject = Betreff

--- a/plugins/email/lang/de_de.lang
+++ b/plugins/email/lang/de_de.lang
@@ -1,8 +1,8 @@
 yform_email_templates = E-Mail Templates
 
 yform_email_key = Key - bitte nicht veraendern
-yform_email_from = E-Mail [z.b.info@redaxo.de]
-yform_email_from_name = E-Mail-Name [z.b. REDAXO Server]
+yform_email_from = Absender-E-Mail [z.b.info@redaxo.de]
+yform_email_from_name = Absender-Name [z.b. REDAXO Server]
 yform_email_subject = Betreff
 yform_email_body = Body
 yform_email_body_html = Body (Html)


### PR DESCRIPTION
Hat mich schon immer irritiert, weil ich mir nie sicher war, ob Absender oder Empfänger gemeint war.