### PR TITLE
getRaw Methode aus rex_yform_manager_dataset undefined

### DIFF
--- a/plugins/manager/boot.php
+++ b/plugins/manager/boot.php
@@ -86,7 +86,7 @@ rex_extension::register('REX_YFORM_SAVED', function (rex_extension_point $ep) {
 
     $dataset = $ep->getParam('form')->getParam('manager_dataset');
     if (!$dataset) {
-        $dataset = rex_yform_manager_dataset::getRaw($ep->getParam('id'), $table->getTableName());
+        $dataset = rex_yform_manager_dataset::getRaw($table->getTableName(), $ep->getParam('id'));
     }
     $dataset->invalidateData();
 

--- a/plugins/manager/lib/yform/manager/table.php
+++ b/plugins/manager/lib/yform/manager/table.php
@@ -367,7 +367,7 @@ class rex_yform_manager_table implements ArrayAccess
      */
     public function getRawDataset($id)
     {
-        return rex_yform_manager_dataset::getRaw($id, $this->getTableName());
+        return rex_yform_manager_dataset::get($this->getTableName(), $id);
     }
 
     /**

--- a/plugins/manager/pages/data_history.php
+++ b/plugins/manager/pages/data_history.php
@@ -8,7 +8,7 @@ $subfunc = rex_request('subfunc', 'string');
 $datasetId = rex_request('dataset_id', 'int');
 $historyId = rex_request('history_id', 'int');
 if ('restore' === $subfunc && $datasetId && $historyId) {
-    $dataset = rex_yform_manager_dataset::getRaw($datasetId, $this->table->getTableName());
+    $dataset = rex_yform_manager_dataset::getRaw($this->table->getTableName(), $datasetId);
 
     if ($dataset->restoreSnapshot($historyId)) {
         echo rex_view::success(rex_i18n::msg('yform_history_restore_success'));


### PR DESCRIPTION
Ich hoffe es lag nicht irgendwie an meiner Installation, oder dass beim Update etwas schief gelaufen ist, auf jeden Fall war die Methode rex_yform_manager_dataset::getRaw undefined und die Lösungen wie in den Commits haben das Problem gelöst – vorübergehend.

Ich sehe, dass hier im Repo die Methode sehr wohl vorhanden ist, der über den Installer verfügbaren Version war sie nicht verfügbar. Sehr komisch.
