### PR TITLE
Angabe mehrere Empfänger durch Komma getrennte Liste

### DIFF
--- a/lib/yform/action/email.php
+++ b/lib/yform/action/email.php
@@ -27,7 +27,10 @@ class rex_yform_action_email extends rex_yform_action_abstract
         }
 
         $mail = new rex_mailer();
-        $mail->AddAddress($mail_to, $mail_to);
+        $recipients = explode(',', $mail_to);
+        foreach ($recipients as $to) {
+            $mail->AddAddress(trim($to), trim($to));
+        }
         $mail->WordWrap = 80;
         $mail->FromName = $mail_from;
         $mail->From = $mail_from;

--- a/lib/yform/action/email.php
+++ b/lib/yform/action/email.php
@@ -27,10 +27,21 @@ class rex_yform_action_email extends rex_yform_action_abstract
         }
 
         $mail = new rex_mailer();
+
+        // add recipients
         $recipients = explode(',', $mail_to);
         foreach ($recipients as $to) {
-            $mail->AddAddress(trim($to), trim($to));
+            $to = str_replace('"', '', trim($to));
+            $name = $to;
+              
+            if (preg_match('/(.+?)<(.+?)>/is', $to, $matches)) {
+                $to = trim($matches[1]);
+                $name = trim($matches[2]);
+            }
+          
+            $mail->AddAddress($to, $name);
         }
+
         $mail->WordWrap = 80;
         $mail->FromName = $mail_from;
         $mail->From = $mail_from;


### PR DESCRIPTION
Möglichkeit hinzugefügt mehrere Email-Empfänger durch Komma getrennt (z.B. `user1@example.com, user2@example.com`) anzugeben