### PR TITLE
getElementMappingOffset muss 0 zurückgeben

### DIFF
--- a/lib/yform/value/abstract.php
+++ b/lib/yform/value/abstract.php
@@ -218,7 +218,7 @@ abstract class rex_yform_value_abstract extends rex_yform_base_abstract
 
     protected function getElementMappingOffset()
     {
-        return 1;
+        return 0;
     }
 
     function setName($name)


### PR DESCRIPTION
Damit das Mapping zwischen der Definition einer Klasse und der Methode getElement() funktioniert, muss getElementMappingOffset() 0 zurückgeben.