### PR TITLE
erlaubte attribute ergänzt

### DIFF
--- a/ytemplates/bootstrap/value.checkbox.tpl.php
+++ b/ytemplates/bootstrap/value.checkbox.tpl.php
@@ -29,7 +29,7 @@ if ($this->getValue() == $value) {
     $attributes['checked'] = 'checked';
 }
 
-$attributes = $this->getAttributeElements($attributes);
+$attributes = $this->getAttributeElements($attributes, ['required', 'disabled', 'autofocus']);
 
 ?>
 <div class="<?= $class_group ?>" id="<?php echo $this->getHTMLId() ?>">


### PR DESCRIPTION
Für `input[type="checkbox"]` sind folgende Attribute erlaubt: `['required', 'disabled', 'autofocus']`
https://www.w3.org/TR/2012/WD-html-markup-20121025/input.checkbox.html