### PR TITLE
Text Leeroption auf string casten

### DIFF
--- a/lib/yform/value/select_sql.php
+++ b/lib/yform/value/select_sql.php
@@ -52,7 +52,7 @@ class rex_yform_value_select_sql extends rex_yform_value_abstract
             $size = 1;
 
             if ($this->getElement('empty_option') == 1) {
-                $options = ['0' => $this->getElement('empty_value')] + $options;
+                $options = ['0' => (string)$this->getElement('empty_value')] + $options;
             }
 
             $default = null;


### PR DESCRIPTION
Wenn für die Leeroption kein Text eingegeben wird, kommt [von hier](https://github.com/yakamara/redaxo_yform/blob/master/lib/yform/base_abstract.php#L77) `false` zurück. Die i18n Funktion [hier](https://github.com/yakamara/redaxo_yform/blob/master/lib/yform/value/abstract.php#L247) streckt daraufhin alle Viere von sich, weil sie einen string möchte und bool bekommt.