### PR TITLE
0 ist ein gülitiger Defaultwert

### DIFF
--- a/lib/yform/value/select_sql.php
+++ b/lib/yform/value/select_sql.php
@@ -59,7 +59,7 @@ class rex_yform_value_select_sql extends rex_yform_value_abstract
             $value = (string) $this->getValue();
 
             if (!array_key_exists($value, $options)) {
-                if ($default) {
+                if ($default OR $default === '0') {
                     $this->setValue([$default]);
                 } else {
                     reset($options);


### PR DESCRIPTION
Damit wird die Leeroption zuverlässig selektiert, wenn noch kein Wert ausgewählt ist.