### PR TITLE
Fehlerbehebung beim Versand von (internen) Formularen

### DIFF
--- a/plugins/manager/lib/yform/manager/dataset.php
+++ b/plugins/manager/lib/yform/manager/dataset.php
@@ -432,6 +432,7 @@ class rex_yform_manager_dataset
 
         $yform->setFieldValue('send', '1', '', 'send');
         $yform->executeFields();
+        $yform->setFieldValue('send', '0', '', 'send');
         $this->messages = $yform->getObjectparams('warning_messages');
 
         return empty($this->messages);
@@ -461,6 +462,7 @@ class rex_yform_manager_dataset
 
         $yform->setFieldValue('send', '1', '', 'send');
         $this->executeForm($yform);
+        $yform->setFieldValue('send', '0', '', 'send');
         $this->messages = $yform->getObjectparams('warning_messages');
 
         return empty($this->messages);


### PR DESCRIPTION
Für nachfolgende Formulare sollte $_REQUEST['send'] nicht auf "1" stehen.
Ganz wichtige Änderung! Hat mich schon zwei Tage gekostet...