### PR TITLE
1:n Verknüpfung bei externer Tabelle

### DIFF
--- a/plugins/manager/lib/yform/value/be_manager_relation.php
+++ b/plugins/manager/lib/yform/value/be_manager_relation.php
@@ -437,11 +437,14 @@ class rex_yform_value_be_manager_relation extends rex_yform_value_abstract
         $source = $table->getRelationsTo($this->params['main_table']);
         $target = $table->getRelationsTo($this->getElement('table'));
         if (!empty($source) && !empty($target)) {
+            if (reset($source)->getName() == reset($target)->getName()) {
+               return ['source' => reset($source)->getName(), 'target' => next($target)->getName()];
+            } 
             return ['source' => reset($source)->getName(), 'target' => reset($target)->getName()];
         }
         return ['source' => null, 'target' => null];
     }
-
+    
     protected function getRelationTableValues()
     {
         $values = [];


### PR DESCRIPTION
getRelationTableFields hat bei extern verknüpfter 1:n Tabelle mit Verknpüfung auf die Datentabelle selbst nicht funktioniert.