### PR TITLE
added missing exit() after header(Location...)

### DIFF
--- a/lib/yform/action/redirect.php
+++ b/lib/yform/action/redirect.php
@@ -43,6 +43,7 @@ class rex_yform_action_redirect extends rex_yform_action_abstract
         if ($url != '') {
             rex_response::cleanOutputBuffers();
             header('Location: ' . $url);
+            exit();
         }
     }
 


### PR DESCRIPTION
ungetestet.. in der regel muss nach einem header(Location...) ein exit() kommen.