### PR TITLE
be-table auf media und medialist erweitert

### DIFF
--- a/plugins/manager/lib/yform/value/be_table.php
+++ b/plugins/manager/lib/yform/value/be_table.php
@@ -25,7 +25,7 @@ class rex_yform_value_be_table extends rex_yform_value_abstract
             $table_array = [];
             $id = $this->getId();
 
-            $columns = explode(',', $this->getElement('columns'));
+            $columns  = preg_split ( "/(?<=[^\w\"]),|,(?=\{)|(?<=[A-Za-z]),(?=[^ ][\w,])|(?<=,\w),/" , $this->getElement('columns') );
             if (count($columns) == 0) {
                 return;
             }
@@ -54,7 +54,7 @@ class rex_yform_value_be_table extends rex_yform_value_abstract
             return;
         }
 
-        $_columns = explode(',', $this->getElement('columns'));
+        $_columns  = preg_split ( "/(?<=[^\w\"]),|,(?=\{)|(?<=[A-Za-z]),(?=[^ ][\w,])|(?<=,\w),/" , $this->getElement('columns') );
         if (count($_columns) == 0) {
             return;
         }

--- a/plugins/manager/ytemplates/bootstrap/value.be_table.tpl.php
+++ b/plugins/manager/ytemplates/bootstrap/value.be_table.tpl.php
@@ -51,20 +51,54 @@ if (count($notice) > 0) {
             var wrapper = jQuery('#<?php echo $this->getHTMLId() ?>');
 
             wrapper.find('#<?= $this->getHTMLId() ?>-add-row').click(function () {
-                $(this).closest('table').find('tbody').append('\
-                    <tr>\
-                        <?php foreach ($columns as $i => $column): ?>\
+                var tr = $('<tr/>'),
+                    regexp = [
+                        // REX_MEDIA
+                        new RegExp("(REX_MEDIA_)", 'g'),
+                        new RegExp("(openREXMedia\\()", 'g'),
+                        new RegExp("(addREXMedia\\()", 'g'),
+                        new RegExp("(deleteREXMedia\\()", 'g'),
+                        new RegExp("(viewREXMedia\\()", 'g'),
+                        // REX_MEDIALIST
+                        new RegExp("(REX_MEDIALIST_SELECT_)", 'g'),
+                        new RegExp("(moveREXMedialist\\()", 'g'),
+                        new RegExp("(openREXMedialist\\()", 'g'),
+                        new RegExp("(addREXMedialist\\()", 'g'),
+                        new RegExp("(deleteREXMedialist\\()", 'g'),
+                        new RegExp("(viewREXMedialist\\()", 'g'),
+                    ],
+                    row_html = '\
+                    <?php foreach ($columns as $i => $column): ?>\
                             <td class="be-value-input"><?php
-                                $field = $columns[$i]['field'];
-                                $field->setValue(null);
-                                $field->params['this']->setObjectparams('form_name', $this->getId() .'.'. $i);
-                                $field->enterObject();
-                                echo strtr($field->params['form_output'][$field->getId()], ["\n" => '', "\r" => '', "'" => "\'"]);
-                            ?></td>\
-                        <?php endforeach ?>\
-                        <td><a class="btn btn-xs btn-delete" href="javascript:void(0)"><i class="rex-icon rex-icon-delete"></i> <?php echo rex_i18n::msg('yform_delete') ?></a></td>\
-                    </tr>\
-                ');
+                        $field = $columns[$i]['field'];
+                        $field->setValue(null);
+                        $field->params['this']->setObjectparams('form_name', $this->getId() . '.' . $i);
+                        $field->enterObject();
+                        echo strtr($field->params['form_output'][$field->getId()], ["\n" => '', "\r" => '', "'" => "\'"]);
+                        ?></td>\
+                    <?php endforeach ?>\
+                    <td><a class="btn btn-xs btn-delete" href="javascript:void(0)"><i class="rex-icon rex-icon-delete"></i> <?php echo rex_i18n::msg('yform_delete') ?></a></td>\
+                ';
+
+                be_table_cnt++;
+
+                for (var i in regexp) {
+                    row_html = row_html.replace(regexp[i], '$1'+ be_table_cnt +'<?= $i ?>');
+                }
+                tr.html(row_html);
+
+                // replace be medialist
+                tr.find('select[id^="REX_MEDIALIST_"]').each(function() {
+                    var $select = $(this),
+                        $input  = $select.parent().children('input:first'),
+                        id = $select.prop('id').replace('REX_MEDIALIST_SELECT_', '');
+
+                    $input.prop('id', 'REX_MEDIALIST_'+ id);
+                });
+
+
+                $(this).closest('table').find('tbody').append(tr);
+                $(document).trigger('be_table:row-added', [tr]);
                 return false;
             });
 


### PR DESCRIPTION
ihr habt da teil entfernt die notwendig sind um REX_MEDIA und REX_MEDIALIST in be-table zu verwenden.

Probiert bitte folgende Spaltenbezeichnungs-Notation: 
`textarea|text|Textblock|||{"rows":"3","class":"redactorEditor2-text"}|,be_media|images|Bilder nach Textblock|1|1|`