### PR TITLE
Fehlende Klasse "yform-element" in mehreren Feld-Templates ergänzt

### DIFF
--- a/ytemplates/bootstrap/value.google_geocode.tpl.php
+++ b/ytemplates/bootstrap/value.google_geocode.tpl.php
@@ -21,7 +21,7 @@ if ($googleapikey != '') {
     var rex_geo_coder = function() {
 
         jQuery("#<?php echo $this->getFieldId() ?>").on("change", function(){
-            
+
         });
 
         jQuery("#<?php echo $this->getHTMLId('google') ?> .yform-google-btnbar .get-position").on("click", function(){
@@ -139,7 +139,7 @@ if ((string) (int) $mapHeight == (string) $mapHeight) {
 
 ?>
 
-<div class="<?php echo $this->getHTMLClass() ?>" id="<?php echo $this->getHTMLId('google') ?>">
+<div class="<?php echo $this->getHTMLClass() ?> yform-element" id="<?php echo $this->getHTMLId('google') ?>">
     <label class="text <?php echo $this->getWarningClass() ?>"><?php echo $this->getElement('label') ?></label>
     <p class="yform-google-btnbar">
         <a class="get-position" href="javascript:void(0);"><?php echo rex_i18n::msg('yform_geo_get_position'); ?></a> |

--- a/ytemplates/bootstrap/value.radio.tpl.php
+++ b/ytemplates/bootstrap/value.radio.tpl.php
@@ -15,7 +15,7 @@ if (count($notices) > 0) {
 
 $class_label = '';
 $class = $this->getElement('required') ? 'form-is-required ' : '';
-$class_group = trim('radio-group form-group ' . $class . $this->getWarningClass());
+$class_group = trim('radio-group form-group yform-element ' . $class . $this->getWarningClass());
 $field_before = '';
 $field_after = '';
 

--- a/ytemplates/bootstrap/value.select.tpl.php
+++ b/ytemplates/bootstrap/value.select.tpl.php
@@ -14,7 +14,7 @@ if (count($notice) > 0) {
 }
 
 $class = $this->getElement('required') ? 'form-is-required ' : '';
-$class_group = trim('form-group ' . $class . $this->getWarningClass());
+$class_group = trim('form-group yform-element ' . $class . $this->getWarningClass());
 
 $class_label[] = 'control-label';
 $field_before = '';

--- a/ytemplates/bootstrap/value.textarea.tpl.php
+++ b/ytemplates/bootstrap/value.textarea.tpl.php
@@ -15,7 +15,7 @@ if (count($notice) > 0) {
 
 $class = $this->getElement('required') ? 'form-is-required ' : '';
 
-$class_group = trim('form-group ' . $this->getWarningClass());
+$class_group = trim('form-group yform-element ' . $this->getWarningClass());
 
 $class_label = ['control-label'];
 $field_before = '';

--- a/ytemplates/bootstrap/value.upload.tpl.php
+++ b/ytemplates/bootstrap/value.upload.tpl.php
@@ -15,7 +15,7 @@ if (count($notice) > 0) {
 
 $class = $this->getElement('required') ? 'form-is-required ' : '';
 
-$class_group = trim('form-group ' . $class . $this->getWarningClass());
+$class_group = trim('form-group yform-element ' . $class . $this->getWarningClass());
 $class_control = trim('form-control');
 
 $class_label = '';


### PR DESCRIPTION
In den Feld-Templates für captcha, google_geocode, radio, select, textarea und uplaod die Klasse yform-element ergänzt. Die Klasse ist in den anderen Feldern jeweils enthalten. Betrifft nur ytemplate/bootstrap. Bezug: #443