### PR TITLE
Data-Ordner (fonts) nicht mehr kopieren

### DIFF
--- a/install.php
+++ b/install.php
@@ -2,8 +2,6 @@
 
 /** @var rex_addon $this */
 
-rex_dir::copy($this->getPath('data'), $this->getDataPath());
-
 foreach ($this->getInstalledPlugins() as $plugin) {
     // use path relative to __DIR__ to get correct path in update temp dir
     $file = __DIR__.'/plugins/'.$plugin->getName().'/install.php';

--- a/lib/yform/value/captcha.php
+++ b/lib/yform/value/captcha.php
@@ -100,7 +100,7 @@ class rex_yform_value_captcha extends rex_yform_value_abstract
     {
         extract($this->captcha_ini);
 
-        $font_path = rex_addon::get('yform')->getDataPath('fonts');
+        $font_path = rex_addon::get('yform')->getPath('data/fonts');
 
         list($padding_top, $padding_right, $padding_bottom, $padding_left) = $this->captcha_split($padding);
         $box_width = ($width - ($padding_left + $padding_right)) / $letters_no;

--- a/lib/yform/value/captcha_calc.php
+++ b/lib/yform/value/captcha_calc.php
@@ -100,7 +100,7 @@ class rex_yform_value_captcha_calc extends rex_yform_value_abstract
     {
         extract($this->captcha_ini);
 
-        $font_path = rex_addon::get('yform')->getDataPath('fonts');
+        $font_path = rex_addon::get('yform')->getPath('data/fonts');
 
         list($padding_top, $padding_right, $padding_bottom, $padding_left) = $this->captcha_split($padding);
         $box_width = ($width - ($padding_left + $padding_right)) / count($this->captcha_letters);

--- a/update.php
+++ b/update.php
@@ -4,9 +4,7 @@
  * @var rex_addon $this
  */
 
-rex_extension::register('OUTPUT_FILTER', function () {
-    rex_dir::copy($this->getPath('data'), $this->getDataPath());
-});
+rex_dir::delete($this->getDataPath('fonts'));
 
 foreach ($this->getInstalledPlugins() as $plugin) {
     // use path relative to __DIR__ to get correct path in update temp dir


### PR DESCRIPTION
Gibt es doch eigentlich keinen Grund für, den Ordner zu kopieren, oder?

(Das macht aktuell in YDeploy Probleme, da wir dort den data-Ordner von yform in shared haben, wegen der Uploads und dadurch fehlen teilweise die Fonts.)