### PR TITLE
be_manager_relation mit be_table widget erweitert

### DIFF
--- a/plugins/manager/assets/manager.css
+++ b/plugins/manager/assets/manager.css
@@ -173,3 +173,78 @@ div.sortable-ghost {
     padding-top: 15px;
 }
 
+
+.formbe_table th.rex-table-action {
+    padding: 4px 8px
+}
+
+.formbe_table .add-mobile-btn, .formbe_table th.rex-table-action .btn {
+    border-radius: 0;
+    line-height: 26px
+}
+
+.formbe_table .add-mobile-btn {
+    margin-bottom: 20px;
+    width: 100%
+}
+
+.formbe_table table {
+    margin: 0 0 4px 0
+}
+
+.formbe_table tbody tr td {
+    padding-left: 8px;
+    padding-top: 30px
+}
+
+.formbe_table tbody tr td:before {
+    line-height: 1;
+    width: 100%
+}
+
+.formbe_table tbody tr td.delete-row {
+    padding-top: 8px
+}
+
+@media screen and (min-width: 480px) {
+    .formbe_table tbody tr td {
+        padding-top: 8px;
+        padding-left: 40%
+    }
+
+    .formbe_table tbody tr td:before {
+        line-height: 34px;
+        width: 35%
+    }
+}
+
+@media screen and (min-width: 768px) {
+    .formbe_table tbody tr td {
+        padding-left: 8px
+    }
+}
+
+.formbe_table .be-value-input .form-group {
+    margin: 0
+}
+
+.formbe_table .be-value-input label {
+    display: none
+}
+
+.formbe_table .be-value-input div.checkbox label {
+    display: block
+}
+
+.formbe_table .btn-delete {
+    border-radius: 0;
+    display: block;
+    line-height: 26px
+}
+
+@media screen and (min-width: 768px) {
+    .formbe_table .add-mobile-btn {
+        display: none
+    }
+}
+

--- a/plugins/manager/lib/yform/manager.php
+++ b/plugins/manager/lib/yform/manager.php
@@ -589,8 +589,8 @@ class rex_yform_manager
                             if ($table) {
                                 $fields = $table->getValueFields(['name' => $field_name]);
                                 if (isset($fields[$field_name])) {
-                                    $target_table = $fields[$field_name]->getElement('table');
-                                    $target_field = $fields[$field_name]->getElement('field');
+                                    $target_table = $fields[$field_name]->getElement('table') ?: $table_name;
+                                    $target_field = $fields[$field_name]->getElement('field') ?: $field_name;
 
                                     $values = rex_yform_value_be_manager_relation::getListValues($target_table, $target_field);
                                     $value = $values[$params['list']->getValue('id')];

--- a/plugins/manager/lib/yform/value/be_manager_relation.php
+++ b/plugins/manager/lib/yform/value/be_manager_relation.php
@@ -26,8 +26,8 @@ class rex_yform_value_be_manager_relation extends rex_yform_value_abstract
         $this->relation['target_table'] = $this->getElement('table'); // Zieltabelle
         $this->relation['target_field'] = $this->getElement('field'); // Zielfield welches angezeigt wird.
 
-        $this->relation['relation_type'] = (int) $this->getElement('type'); // select single = 0 / select multiple = 1 / popup single = 2 / popup multiple = 3 / popup 1-n = 4/ inline 1-n = 5
-        if ($this->relation['relation_type'] > 5) {
+        $this->relation['relation_type'] = (int)$this->getElement('type'); // select single = 0 / select multiple = 1 / popup single = 2 / popup multiple = 3 / popup 1-n = 4 / inline 1-n = 5 / be_table multitple n-m = 6
+        if ($this->relation['relation_type'] > 6) {
             $this->relation['relation_type'] = 0;
         }
 
@@ -143,6 +143,134 @@ class rex_yform_value_be_manager_relation extends rex_yform_value_abstract
             $link = self::addOpenerParams($link);
             $link .= '&rex_yform_manager_popup=1';
             $this->params['form_output'][$this->getId()] = $this->parse('value.be_manager_relation.tpl.php', compact('valueName', 'options', 'link', 'send'));
+        }
+
+        // --------------------------------------- BE_TABLE, n-m
+        if ($this->relation['relation_type'] == 6) {
+            $sql = rex_sql::factory();
+            $beCols = [];
+            $field = new rex_yform_value_be_table();
+            $_fields = $this->getRelationTableFields();
+
+            foreach ($_fields['fields'] as $_field) {
+                if ($_fields['source'] == $_field->getName()) {
+                    continue;
+                }
+
+                if ($_field->getElement('type_id') == 'value') {
+                    $class = 'rex_yform_value_'. $_field->getElement('type_name');
+                }
+                else if ($_field->getElement('type_id') == 'validate') {
+                    $class = 'rex_yform_validate_'. $_field->getElement('type_name');
+                }
+                else {
+                    $class = 'rex_yform_action_'. $_field->getElement('type_name');
+                }
+                $Field = new $class();
+                $columns = [$_field->getElement('type_name')];
+
+                foreach ($Field->getDefinitions()['values'] as $definitionName => $definition) {
+                    $columns[] = $_field->getElement($definitionName);
+                }
+
+                $beCols[] = implode('|', $columns);
+            }
+
+            $yfparams = \rex_yform::factory()->objparams;
+            $yfparams['this'] = \rex_yform::factory();
+
+            $field->loadParams($yfparams, ['be_table']);
+            $field->setName($this->getName());
+            $field->init();
+            $field->setLabel($this->getElement('label'));
+            $field->setElement('columns', implode(',', $beCols));
+            $field->setElement('no_db', 'no_db');
+            $field->setId($this->getId());
+
+            $field->params['this']->setObjectparams('form_name', $this->getId());
+            $field->params['this']->setObjectparams('form_ytemplate', $this->params['this']->getObjectparams('form_ytemplate'));
+            $field->params['this']->setObjectparams('main_id', $this->params['this']->getObjectparams('main_id'));
+            $field->params['form_name'] = $field->getName();
+            $field->params['form_label_type'] = 'html';
+            $field->params['send'] = $send;
+
+
+            if ($send) {
+                $field->preValidateAction();
+                $lastIds = [];
+                $values = json_decode($field->getValue());
+                $table = rex_yform_manager_table::get($this->getElement('relation_table'));
+
+                $sql->beginTransaction();
+
+                foreach ($values as $counter => $row) {
+                    $row_data = [];
+                    $fieldIndex = 0;
+
+                    foreach ($_fields['fields'] as $_field) {
+                        if ($_field->getName() == $_fields['source']) {
+                            $row_data[$_field->getName()] = $this->params['main_id'];
+                        }
+                        else {
+                            $row_data[$_field->getName()] = is_array($row[$fieldIndex]) ? implode(',', $row[$fieldIndex]) : $row[$fieldIndex];
+                            $fieldIndex++;
+                        }
+                    }
+
+                    $Dataset = $table
+                        ->query()
+                        ->where($_fields['source'], $row_data[$_fields['source']])
+                        ->where($_fields['target'], $row_data[$_fields['target']])
+                        ->findOne();
+
+                    if (!$Dataset) {
+                        $Dataset = $table->createDataset();
+                    }
+
+                    foreach ($row_data as $fieldname => $value) {
+                        $Dataset->setValue($fieldname, $value);
+                    }
+
+                    if ($Dataset->save()) {
+                        $lastIds[] = $Dataset->getId();
+                    }
+                    else {
+                        $this->params['warning'][$this->getId()][$counter] = $this->params['error_class'];
+                        $this->params['warning_messages'][$this->getId()] = implode('<br/>', $Dataset->getMessages());
+                    }
+                }
+
+                $this->setValue($lastIds);
+            }
+            else if (count($this->getValue())) {
+                $columns = array_diff(array_keys($_fields['fields']), [$_fields['source']]);
+
+                $values = $sql->setQuery('
+                    SELECT '. implode(', ', $columns) .'
+                    FROM '. $this->getElement('relation_table') . ' 
+                    WHERE 
+                        ' . $sql->escapeIdentifier($_fields['source']) . ' = ' . $this->params['main_id'] . ' 
+                        AND ' . $sql->escapeIdentifier($_fields['target']) . ' IN(' . implode(',', $this->getValue()) . ') 
+                ')->getArray();
+
+                $field->setValue(json_encode($values));
+            }
+
+
+            if ($send) {
+                $field->params['warning'][$this->getId()] = $this->params['warning'][$this->getId()];
+
+                if (!empty ($this->params['warning_messages'])) {
+                    $sql->rollBack();
+                }
+                else  {
+                    $sql->commit();
+                }
+            }
+
+            $field->enterObject();
+            $this->params['form_output'][$this->getId()] = $field->params['form_output'][$field->getId()];
+
         }
 
         // --------------------------------------- INLINE, 1-n
@@ -427,6 +555,14 @@ class rex_yform_value_be_manager_relation extends rex_yform_value_abstract
             return;
         }
 
+        if ($this->relation['relation_type'] == 6) {
+            $sql = rex_sql::factory();
+            $sql->setTable($relationTable);
+            $sql->setWhere(' ' . $sql->escapeIdentifier($relationTableField['source']) . ' =' . $source_id . ' AND id NOT IN (' . implode(',', $this->getValue()) . ')');
+            $sql->delete();
+            return;
+        }
+
         // ----- Value angleichen -> immer Array mit IDs daraus machen
         $values = [];
         if (!is_array($this->getValue())) {
@@ -468,7 +604,7 @@ class rex_yform_value_be_manager_relation extends rex_yform_value_abstract
                 'label' => ['type' => 'text',    'label' => rex_i18n::msg('yform_values_defaults_label')],
                 'table' => ['type' => 'table',   'label' => rex_i18n::msg('yform_values_be_manager_relation_table')],
                 'field' => ['type' => 'text',    'label' => rex_i18n::msg('yform_values_be_manager_relation_field')],
-                'type' => ['type' => 'choice',  'label' => rex_i18n::msg('yform_values_be_manager_relation_type'), 'choices' => ['0' => 'select (single)', '1' => 'select (multiple)', '2' => 'popup (single)', '3' => 'popup (multiple)', '4' => 'popup (multiple 1-n)', '5' => 'inline (multiple 1-n)']], // ,popup (multiple / relation)=4
+                'type' => ['type' => 'choice',  'label' => rex_i18n::msg('yform_values_be_manager_relation_type'), 'choices' => ['0' => 'select (single)', '1' => 'select (multiple)', '2' => 'popup (single)', '3' => 'popup (multiple)', '4' => 'popup (multiple 1-n)', '5' => 'inline (multiple 1-n)', '6' => 'be_table (multiple n-m)']], // ,popup (multiple / relation)=4
                 'empty_option' => ['type' => 'boolean', 'label' => rex_i18n::msg('yform_values_be_manager_relation_empty_option')],
                 'empty_value' => ['type' => 'text',    'label' => rex_i18n::msg('yform_values_be_manager_relation_empty_value')],
                 'size' => ['type' => 'text', 'name' => 'boxheight',    'label' => rex_i18n::msg('yform_values_be_manager_relation_size')],
@@ -753,18 +889,39 @@ class rex_yform_value_be_manager_relation extends rex_yform_value_abstract
 
     private static function getRelationTableFieldsForTables($mainTable, $relationTable, $targetTable)
     {
+        $result = [];
         $table = rex_yform_manager_table::get($relationTable);
         $source = $table->getRelationsTo($mainTable);
         $target = $table->getRelationsTo($targetTable);
+        $fields = $table->getFields();
+
 
         if (empty($source) || empty($target)) {
-            return ['source' => null, 'target' => null];
+            $result = [
+                'source' => null,
+                'target' => null,
+                'fields' => []
+            ];
+        }
+        else if (reset($source)->getName() == reset($target)->getName()) {
+            $result = [
+                'source' => reset($source)->getName(),
+                'target' => next($target)->getName(),
+                'fields' => []
+            ];
+        }
+        else {
+            $result = [
+                'source' => reset($source)->getName(),
+                'target' => reset($target)->getName(),
+                'fields' => []
+            ];
         }
 
-        if (reset($source)->getName() == reset($target)->getName()) {
-            return ['source' => reset($source)->getName(), 'target' => next($target)->getName()];
+        foreach ($fields as $field) {
+            $result['fields'][$field->getName()] = $field;
         }
 
-        return ['source' => reset($source)->getName(), 'target' => reset($target)->getName()];
+        return $result;
     }
 }

--- a/plugins/manager/ytemplates/bootstrap/value.be_table.tpl.php
+++ b/plugins/manager/ytemplates/bootstrap/value.be_table.tpl.php
@@ -2,7 +2,7 @@
 $class_group = trim('form-group ' . $this->getHTMLClass() . ' ' . $this->getWarningClass());
 
 $data_index = 0;
-$notice = [];
+$notice     = [];
 if ($this->getElement('notice') != '') {
     $notice[] = rex_i18n::translate($this->getElement('notice'), false);
 }
@@ -15,6 +15,9 @@ if (count($notice) > 0) {
     $notice = '';
 }
 
+$ytemplates = $this->params['this']->getObjectparams('form_ytemplate');
+$main_id    = $this->params['this']->getObjectparams('main_id');
+
 ?>
 <div class="<?= $class_group ?>" id="<?= $this->getHTMLId() ?>">
     <label class="control-label" for="<?php echo $this->getFieldId() ?>"><?php echo $this->getLabel() ?></label>
@@ -24,40 +27,51 @@ if (count($notice) > 0) {
             <?php foreach ($columns as $column): ?>
                 <th><?php echo htmlspecialchars($column['label']) ?></th>
             <?php endforeach ?>
-            <th class="rex-table-action"><a class="btn btn-xs btn-default" id="<?= $this->getHTMLId() ?>-add-row" href="javascript:void(0);"><i class="rex-icon rex-icon-add"></i> <?php echo rex_i18n::msg('yform_add_row') ?></a></th>
+            <th class="rex-table-action"><a class="btn btn-xs btn-primary" id="<?= $this->getHTMLId() ?>-add-row" href="javascript:void(0);"><i class="rex-icon rex-icon-add"></i> <?php echo rex_i18n::msg('yform_add_row') ?></a></th>
         </tr>
         </thead>
         <tbody>
         <?php foreach ($data as $data_index => $row): ?>
             <tr>
                 <?php foreach ($columns as $i => $column): ?>
-                    <td class="be-value-input">
+                    <td class="be-value-input" data-title="<?= rex_escape($column['label'], 'html_attr') ?>">
                         <?php
-                            $field = $column['field'];
-                            $field->params['this']->setObjectparams('form_name', $this->getId() .'.'. $i);
-                            $field->params['form_name'] = $field->getName();
-                            $field->params['form_label_type'] = 'html';
-                            $field->params['send'] = false;
-                            $field->setValue($row[$i] ?: '');
-                            $field->setId($data_index);
-                            $field->enterObject();
-                            echo $field->params['form_output'][$field->getId()]
+                        $rowData = array_values($row);
+                        $field = $column['field'];
+                        $field->params['this']->setObjectparams('form_name', $this->getId() . '.' . $i);
+                        $field->params['this']->setObjectparams('form_ytemplate', $ytemplates);
+                        $field->params['this']->setObjectparams('main_id', $main_id);
+                        $field->params['form_name']       = $field->getName();
+                        $field->params['form_label_type'] = 'html';
+                        $field->params['send']            = false;
+
+                        if ($field->getElement(0) == 'be_manager_relation') {
+                            $field->params['main_table'] = $field->getElement('table');
+                            $field->setName($field->getElement('field'));
+                        }
+                        $field->setValue($rowData[$i] ?: '');
+                        $field->setId($data_index);
+                        $field->enterObject();
+                        echo $field->params['form_output'][$field->getId()]
                         ?>
                     </td>
                 <?php endforeach ?>
-                <td><a class="btn btn-xs btn-delete" href="javascript:void(0)"><i class="rex-icon rex-icon-delete"></i> <?php echo rex_i18n::msg('yform_delete') ?></a></td>
+                <td class="delete-row"><a class="btn btn-xs btn-delete" href="javascript:void(0)"><i class="rex-icon rex-icon-delete"></i> <?php echo rex_i18n::msg('yform_delete') ?></a></td>
             </tr>
         <?php endforeach ?>
         </tbody>
     </table>
+    <a class="btn btn-primary btn-xs add-mobile-btn" id="<?= $this->getHTMLId() ?>-add-mobile-row" href="javascript:void(0);"><i class="rex-icon rex-icon-add"></i> <?php echo rex_i18n::msg('yform_add_row') ?></a>
 
     <script type="text/javascript">
         (function () {
             var wrapper = jQuery('#<?php echo $this->getHTMLId() ?>'),
-            	be_table_cnt = <?= (int) $data_index ?>;
+                be_table_cnt = <?= (int)$data_index ?>;
 
-            wrapper.find('#<?= $this->getHTMLId() ?>-add-row').click(function () {
-                var tr = $('<tr/>'),
+            wrapper.find('#<?= $this->getHTMLId() ?>-add-row, #<?= $this->getHTMLId() ?>-add-mobile-row').click(function () {
+                var $this = $(this),
+                    $table = $this.parents('.formbe_table').children('table'),
+                    tr = $('<tr/>'),
                     regexp = [
                         // REX_MEDIA
                         new RegExp("(REX_MEDIA_)", 'g'),
@@ -75,41 +89,48 @@ if (count($notice) > 0) {
                     ],
                     row_html = '\
                     <?php foreach ($columns as $i => $column): ?>\
-                            <td class="be-value-input"><?php
+                            <td class="be-value-input" data-title="<?= $column['label'] ?>"><?php
                         $field = $columns[$i]['field'];
                         $field->params['this']->setObjectparams('form_name', $this->getId() . '.' . $i);
+                        $field->params['this']->setObjectparams('form_ytemplate', $ytemplates);
+                        $field->params['this']->setObjectparams('main_id', $main_id);
                         $field->params['form_name'] = $field->getName();
                         $field->params['form_label_type'] = 'html';
                         $field->params['send'] = false;
+
+                        if ($field->getElement(0) == 'be_manager_relation') {
+                            $field->params['main_table'] = $field->getElement('table');
+                            $field->setName($field->getElement('field'));
+                        }
                         $field->setValue(null);
                         $field->setId('{{FIELD_ID}}');
                         $field->enterObject();
                         echo strtr($field->params['form_output'][$field->getId()], ["\n" => '', "\r" => '', "'" => "\'"]);
                         ?></td>\
                     <?php endforeach ?>\
-                    <td><a class="btn btn-xs btn-delete" href="javascript:void(0)"><i class="rex-icon rex-icon-delete"></i> <?php echo rex_i18n::msg('yform_delete') ?></a></td>\
+                    <td class="delete-row"><a class="btn btn-xs btn-delete" href="javascript:void(0)"><i class="rex-icon rex-icon-delete"></i> <?php echo rex_i18n::msg('yform_delete') ?></a></td>\
                 ';
 
                 be_table_cnt++;
                 // set new row field ids
                 row_html = row_html.replace(new RegExp('{{FIELD_ID}}', 'g'), be_table_cnt);
+                row_html = row_html.replace(new RegExp('--FIELD_ID--', 'g'), be_table_cnt);
 
                 for (var i in regexp) {
-                    row_html = row_html.replace(regexp[i], '$1'+ be_table_cnt +'<?= $i ?>');
+                    row_html = row_html.replace(regexp[i], '$1' + be_table_cnt + '<?= $i ?>');
                 }
                 tr.html(row_html);
 
                 // replace be medialist
-                tr.find('select[id^="REX_MEDIALIST_"]').each(function() {
+                tr.find('select[id^="REX_MEDIALIST_"]').each(function () {
                     var $select = $(this),
-                        $input  = $select.parent().children('input:first'),
+                        $input = $select.parent().children('input:first'),
                         id = $select.prop('id').replace('REX_MEDIALIST_SELECT_', '');
 
-                    $input.prop('id', 'REX_MEDIALIST_'+ id);
+                    $input.prop('id', 'REX_MEDIALIST_' + id);
                 });
 
-
-                $(this).closest('table').find('tbody').append(tr);
+                $table.find('tbody').append(tr);
                 $(document).trigger('be_table:row-added', [tr]);
                 return false;
             });


### PR DESCRIPTION
man kann somit neben select, popup und inline nun auch be_table als be_manager_relation input verwenden.
VORTEIL: wenn man eine N-M Tabelle hat, welche neben der Relation noch weiter Felder beinhaltet kann man die damit einpflegen

Zuatz: be_table wurde noch etwas verbessert sodass man es nun auch mobil verwenden kann