### PR TITLE
fix query, adding backticks

### DIFF
--- a/plugins/manager/lib/yform/value/prio.php
+++ b/plugins/manager/lib/yform/value/prio.php
@@ -37,7 +37,7 @@ class rex_yform_value_prio extends rex_yform_value_abstract
                 $selectFields[] = $field;
             }
             $sql->setQuery(sprintf(
-                'SELECT id, %s, %s as prio FROM %s%s ORDER BY %2$s',
+                'SELECT id, `%s`, `%s` as prio FROM %s%s ORDER BY %2$s',
                 implode(', ', $selectFields),
                 $this->getElement('name'),
                 $this->params['main_table'],


### PR DESCRIPTION
prevents errors when using reserverd words (like "desc" (abbr. for description in my case)