### PR TITLE
Tabelle in utf8mb4 konvertieren

### DIFF
--- a/plugins/email/install.php
+++ b/plugins/email/install.php
@@ -19,3 +19,6 @@ rex_sql_table::get(rex::getTable('yform_email_template'))
     ->ensureColumn(new rex_sql_column('body_html', 'text'))
     ->ensureColumn(new rex_sql_column('attachments', 'text'))
     ->ensure();
+
+$c = rex_sql::factory();
+$c->setQuery('ALTER TABLE `' . rex::getTable('yform_email_template') . '` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;');


### PR DESCRIPTION
Einzige YForm Tabelle, die beim Upgrade auf 3.0 nicht konvertiert wird. Das war bestimmt keine Absicht, oder?