### PR TITLE
Upload-Dialogfeld per Filter auf gewählte Filetypes begrenzen

### DIFF
--- a/ytemplates/bootstrap/value.mediafile.tpl.php
+++ b/ytemplates/bootstrap/value.mediafile.tpl.php
@@ -19,7 +19,7 @@ $class_group = trim('form-group ' . $this->getHTMLClass() . ' ' . $this->getWarn
 
 <div class="<?= $class_group ?>">
     <label for="<?= $this->getFieldId() ?>"><?= $this->getLabel() ?></label>
-    <input type="file" id="<?= $this->getFieldId() ?>" name="file_<?= md5($this->getFieldName('file')) ?>" />
+    <input type="file" id="<?= $this->getFieldId() ?>" name="file_<?= md5($this->getFieldName('file')) ?>" accept="<?= $this-getElement("types") ?>" />
     <?php if ($this->getValue()): ?>
         <div class="help-block">
             <dl class="<?= $this->getHTMLClass() ?>-info">

--- a/ytemplates/classic/value.mediafile.tpl.php
+++ b/ytemplates/classic/value.mediafile.tpl.php
@@ -15,5 +15,5 @@
             <label for="<?php echo $this->getFieldId('delete') ?>">Datei löschen</label>
         </span>
     <?php endif ?>
-    <input class="uploadbox clickmedia <?php echo $this->getWarningClass() ?>" id="<?php echo $this->getFieldId() ?>" name="file_<?php echo md5($this->getFieldName('file')) ?>" type="file" />
+    <input class="uploadbox clickmedia <?php echo $this->getWarningClass() ?>" id="<?php echo $this->getFieldId() ?>" name="file_<?php echo md5($this->getFieldName('file')) ?>" accept="<?= $this-getElement("types") ?>" type="file" />
 </p>


### PR DESCRIPTION
Das Upload-Dialogfeld hat bisher unabhängig von im yForm mitgegebener Typ-Begrenzung IMMER eine Auswahl aller Dateien ermöglicht ("all types *.*).
Mit dieser Erweiterung wird das Dialogfeld entsprechend der gewünschten Filetypes bereits bei der Usereingabe angepasst und lässt nur die Eingabe des gewünschtes Typs zu!

Die Änderung wurde einmal im yTemplate "bootstrap" und einmal in "classic" hinzugefügt...