### PR TITLE
Standard CSRF token invalid message auf core Meldung gesetzt

### DIFF
--- a/lib/yform.php
+++ b/lib/yform.php
@@ -56,7 +56,7 @@ class rex_yform
         $this->objparams['Error-Code-InsertQueryError'] = 'ErrorCode - InsertQueryError';
 
         $this->objparams['csrf_protection'] = true;
-        $this->objparams['csrf_protection_error_message'] = '{{ csrf.error }}';
+        $this->objparams['csrf_protection_error_message'] = rex_i18n::msg('csrf_token_invalid');
 
         $this->objparams['getdata'] = false;
         $this->objparams['fixdata'] = [];


### PR DESCRIPTION
Als Standardmeldung ward geschrieben:
`$this->objparams['csrf_protection_error_message'] = '{{ csrf.error }}'`
Ein Sprog-Label. Das macht wenig Sinn, oder?
Ich hab es mal durch die Meldung ersetzt, die im core-lang-file steht, also:
`rex_i18n::msg('csrf_token_invalid')`
