### PR TITLE
Fix für Datetime

### DIFF
--- a/lib/yform/value/datetime.php
+++ b/lib/yform/value/datetime.php
@@ -160,7 +160,7 @@ class rex_yform_value_datetime extends rex_yform_value_abstract
             return;
         }
 
-        $format = self::datetime_getFormat($this->datetime_getFormat());
+        $format = self::datetime_getFormat($this->getElement('format'));
 
         $yearStart = (int) $this->getElement('year_start');
 


### PR DESCRIPTION
Das Datetime Feld hat in Version 3.2 nur den Default zurück gegeben. So sollte es nun passen!