### PR TITLE
attach all or specific upload fields as email attachments

### DIFF
--- a/lib/yform/action/attach.php
+++ b/lib/yform/action/attach.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * yform.
+ *
+ */
+
+
+
+class rex_yform_action_attach extends rex_yform_action_abstract
+{
+    public function executeAction()
+    {
+        $fields = array_filter(explode(",", $this->getElement(2))); // specific fields
+        $override = (bool) $this->getElement(3) ?? false; // will replace attached files
+        $uploaded_files = &$this->params['value_pool']['files']; // form uploaded files
+        $email_attachments = &$this->params['value_pool']['email_attachments']; // attached files
+
+        if (count($fields)) {
+            if ($override) {
+                $email_attachments = [];
+            }
+            foreach ($uploaded_files as $file) {
+                $email_attachments[] = $file;
+            }
+        } else {
+            if ($override) {
+                $email_attachments = [];
+            }
+            foreach ($fields as $field) {
+                $email_attachments[] = $uploaded_files[$field];
+            }
+        }
+    }
+
+    public function getDescription()
+    {
+        return 'action|attach|opt:uploadfields(upload1,upload2,upload3)|opt:replace(0=default/1)';
+    }
+}


### PR DESCRIPTION
closes #458 #134 #348

vielen Dank @claudihey für den Anlass dazu :)

Action verwenden

`action|attach|opt:feldname1,feldname2|opt:override(0/1)`

Wenn kein Feldname angegeben wird, werden alle Uploads angehängt
Wenn override aktiviert ist, werden alle zuvor angehängten Dateien zunächst entfernt.

Dadurch ist es möglich, unterschiedliche Anhänge in unterschiedlichen Mailtemplates zu verwenden. Bspw. eine Bestätigungsmail an einen Bewerber zu schicken (ohne Anhänge) und eine Mail mit Anhängen an den Betreiber der Website.