### PR TITLE
Prevent negative integer results for crc32-call

### DIFF
--- a/plugins/manager/ytemplates/bootstrap/value.be_manager_inline_relation.tpl.php
+++ b/plugins/manager/ytemplates/bootstrap/value.be_manager_inline_relation.tpl.php
@@ -2,7 +2,7 @@
 
 $class_group = trim('form-group ' . $this->getHTMLClass()); // . ' ' . $this->getWarningClass()
 
-$id = sprintf('%u', crc32($this->params['form_name']) . rand(0, 10000) . $this->getId());
+$id = sprintf('%u', crc32($this->params['form_name'])) . rand(0, 10000) . $this->getId();
 
 $notice = [];
 if ($this->getElement('notice') != '') {

--- a/plugins/manager/ytemplates/bootstrap/value.be_manager_inline_relation.tpl.php
+++ b/plugins/manager/ytemplates/bootstrap/value.be_manager_inline_relation.tpl.php
@@ -2,7 +2,7 @@
 
 $class_group = trim('form-group ' . $this->getHTMLClass()); // . ' ' . $this->getWarningClass()
 
-$id = crc32($this->params['form_name']) . rand(0, 10000) . $this->getId();
+$id = sprintf('%u', crc32($this->params['form_name']) . rand(0, 10000) . $this->getId());
 
 $notice = [];
 if ($this->getElement('notice') != '') {

--- a/plugins/manager/ytemplates/bootstrap/value.be_manager_relation.tpl.php
+++ b/plugins/manager/ytemplates/bootstrap/value.be_manager_relation.tpl.php
@@ -2,7 +2,7 @@
 
 $class_group = trim('form-group ' . $this->getHTMLClass() . ' ' . $this->getWarningClass());
 
-$id = crc32($this->params['form_name']. rand(0, 100). $this->getId())  ;
+$id = sprintf('%u', crc32($this->params['form_name']. rand(0, 100). $this->getId()));
 
 $notice = [];
 if ($this->getElement('notice') != '') {


### PR DESCRIPTION
See **Warning** at https://www.php.net/crc32:

> Because PHP's integer type is signed many crc32 checksums will result in negative integers on 32bit platforms. On 64bit installations all crc32() results will be positive integers though.
> 
> So you need to use the "%u" formatter of sprintf() or printf() to get the string representation of the unsigned crc32() checksum in decimal format.

