### PR TITLE
Update tools.js

### DIFF
--- a/plugins/tools/assets/tools.js
+++ b/plugins/tools/assets/tools.js
@@ -1,4 +1,4 @@
-$(document).on('ready pjax:success',function() {
+$(document).on('rex:ready',function() {
 
     var monthNames = [
         "January",


### PR DESCRIPTION
Tools mit Redaxo 5.9 auf Grund von jQuery 3 nicht mehr funktionsfähig, daher auf Event rex:ready umstellen. 
https://jquery.com/upgrade-guide/3.0/#breaking-change-on-quot-ready-quot-fn-removed