### PR TITLE
Tabellentitel über Addon ausblendbar machen

### DIFF
--- a/plugins/manager/lib/yform/manager.php
+++ b/plugins/manager/lib/yform/manager.php
@@ -133,7 +133,10 @@ class rex_yform_manager
         }
 
         $description = ($this->table->getDescription() == '') ? '' : '<br />' . $this->table->getDescription();
-
+        
+        $addonkey = rex_be_controller::getCurrentPagePart(1);
+        $table = rex_be_controller::getCurrentPagePart(2);
+        
         if (!rex_addon::get($addonkey)->getProperty('page')['subpages'][$table]['hide_title']) {
             echo rex_view::title(rex_i18n::msg('yform_table') . ': ' . rex_i18n::translate($this->table->getName()) . ' <small>[' . $this->table->getTablename() . ']' . $description . '</small>', '');            
         }

--- a/plugins/manager/lib/yform/manager.php
+++ b/plugins/manager/lib/yform/manager.php
@@ -134,7 +134,9 @@ class rex_yform_manager
 
         $description = ($this->table->getDescription() == '') ? '' : '<br />' . $this->table->getDescription();
 
-        echo rex_view::title(rex_i18n::msg('yform_table') . ': ' . rex_i18n::translate($this->table->getName()) . ' <small>[' . $this->table->getTablename() . ']' . $description . '</small>', '');
+        if (!rex_addon::get($addonkey)->getProperty('page')['subpages'][$table]['hide_title']) {
+            echo rex_view::title(rex_i18n::msg('yform_table') . ': ' . rex_i18n::translate($this->table->getName()) . ' <small>[' . $this->table->getTablename() . ']' . $description . '</small>', '');            
+        }
 
         if ($func != '' && in_array($func, ['delete', 'dataset_delete', 'truncate_table'])) {
             if (!rex_csrf_token::factory($_csrf_key)->isValid()) {

--- a/plugins/manager/lib/yform/manager.php
+++ b/plugins/manager/lib/yform/manager.php
@@ -135,9 +135,10 @@ class rex_yform_manager
         $description = ($this->table->getDescription() == '') ? '' : '<br />' . $this->table->getDescription();
         
         $addonkey = rex_be_controller::getCurrentPagePart(1);
-        $table = rex_be_controller::getCurrentPagePart(2);
+        $pages = explode('/', rex_be_controller::getCurrentPage());
+        $subpage = end($pages);
         
-        if (!rex_addon::get($addonkey)->getProperty('page')['subpages'][$table]['hide_title']) {
+        if (!rex_addon::get($addonkey)->getProperty('page')['subpages'][$subpage]['hide_title']) {
             echo rex_view::title(rex_i18n::msg('yform_table') . ': ' . rex_i18n::translate($this->table->getName()) . ' <small>[' . $this->table->getTablename() . ']' . $description . '</small>', '');            
         }
 


### PR DESCRIPTION
#836 

Beim Einbinden der Tabelle könnte so geprüft werden, ob es für die jeweilige Addon Seite einen Parameter `hide_title` in der `package.yml` gibt und dementsprechend der Titel ausgegeben wird oder nicht. Der Parameter muss explizit auf `true` gesetzt werden, andernfalls wird der Titel wie gewohnt ausgegeben.

Beispielauszug aus der `package.yml ` eines Addons

```yml

        Product:
            title: 'translate:page_product'
            icon: rex-icon fa-info-circle
            perm: demo_yorm[Product]
            subPath: ../yform/plugins/manager/pages/data_edit.php
            hide_title: true
            href: {page: demo_yorm/Product, table_name: rex_product}
```