### PR TITLE
Tabellentitel per EP

### DIFF
--- a/plugins/manager/lib/yform/manager.php
+++ b/plugins/manager/lib/yform/manager.php
@@ -134,7 +134,16 @@ class rex_yform_manager
 
         $description = ($this->table->getDescription() == '') ? '' : '<br />' . $this->table->getDescription();
 
-        echo rex_view::title(rex_i18n::msg('yform_table') . ': ' . rex_i18n::translate($this->table->getName()) . ' <small>[' . $this->table->getTablename() . ']' . $description . '</small>', '');
+        echo rex_extension::registerPoint(
+            new rex_extension_point(
+                'YFORM_MANAGER_DATA_PAGE_HEADER',
+                rex_view::title(rex_i18n::msg('yform_table') . ': ' . rex_i18n::translate($this->table->getName()) . ' <small>[' . $this->table->getTablename() . ']' . $description . '</small>', ''),
+                [
+                    'yform' => $this,
+                    'table' => $this->table->getTablename()
+                ]
+            )
+        );
 
         if ($func != '' && in_array($func, ['delete', 'dataset_delete', 'truncate_table'])) {
             if (!rex_csrf_token::factory($_csrf_key)->isValid()) {

--- a/plugins/manager/lib/yform/manager.php
+++ b/plugins/manager/lib/yform/manager.php
@@ -139,8 +139,7 @@ class rex_yform_manager
                 'YFORM_MANAGER_DATA_PAGE_HEADER',
                 rex_view::title(rex_i18n::msg('yform_table') . ': ' . rex_i18n::translate($this->table->getName()) . ' <small>[' . $this->table->getTablename() . ']' . $description . '</small>', ''),
                 [
-                    'yform' => $this,
-                    'table' => $this->table->getTablename()
+                    'yform' => $this
                 ]
             )
         );


### PR DESCRIPTION
Aus irgendeinem Grund ist das ursprüngliche Repo verschwunden, Start war ursprünglich hier. #843

@christophboecker hat hier wohl die sauberste Variante geliefert um den Tabellentitel anzusprechen und sofern man möchte auch im eigenen Addon in der boot.php wieder auszublenden. Snippet wäre dann dieses hier:

```php
rex_extension::register('YFORM_MANAGER_DATA_PAGE_HEADER', function($ep) {
    //Sofern nur bei einer Tabelle gewünscht
    if ($ep->getParam('table') === 'rex_product') {
        $ep->setSubject('');
    }
}, rex_extension::LATE);
```

Wäre schön, wenn der PR es in die nächste Version schafft ;)