### PR TITLE
Falls Popup-fenster: verkürzter Titel

### DIFF
--- a/plugins/manager/lib/yform/manager.php
+++ b/plugins/manager/lib/yform/manager.php
@@ -132,7 +132,7 @@ class rex_yform_manager
             $this->setLinkVars($searchObject->getSearchVars());
         }
 
-        $description = ($this->table->getDescription() == '' || $popup) ? '' : '<br />' . $this->table->getDescription();
+        $description =  $popup || ($this->table->getDescription() == '') ? '' : '<br />' . $this->table->getDescription();
 
         echo rex_view::title(rex_i18n::msg('yform_table') . ': ' . rex_i18n::translate($this->table->getName()) . ' <small>[' . $this->table->getTablename() . ']' . $description . '</small>', '');
 

--- a/plugins/manager/lib/yform/manager.php
+++ b/plugins/manager/lib/yform/manager.php
@@ -132,7 +132,7 @@ class rex_yform_manager
             $this->setLinkVars($searchObject->getSearchVars());
         }
 
-        $description = ($this->table->getDescription() == '') ? '' : '<br />' . $this->table->getDescription();
+        $description = ($this->table->getDescription() == '' || $popup) ? '' : '<br />' . $this->table->getDescription();
 
         echo rex_view::title(rex_i18n::msg('yform_table') . ': ' . rex_i18n::translate($this->table->getName()) . ' <small>[' . $this->table->getTablename() . ']' . $description . '</small>', '');
 


### PR DESCRIPTION
Die Tabellenbeschreibung ist eigentlich Teil des Titels, sprengt aber den Rahmen des Platzes bei Popup-Fenster. Lösung: wenn Popup, dann keine Tabellenbeschreibung ausgeben.

Wurde beschrieben hier #855. 

Die Grundfuntionalität für Popup-Fenster, ist im Addon "be_style". Man kann draüber streiten, ob "be_style" zu große Titel abfangen müsste oder ob "yform" sich an die Fähigkeiten und Limitierungen von "be_style" anpassen muss.  Mein Vorschlag hiermit: in "yform" anpassen, weil es einfach und schnell geht. 