### PR TITLE
Suchfunktion: Auswertung verbessert, SQL-Fehler vermieden #860

### DIFF
--- a/lib/yform/value/date.php
+++ b/lib/yform/value/date.php
@@ -205,16 +205,24 @@ class rex_yform_value_date extends rex_yform_value_abstract
     public static function getSearchFilter($params)
     {
         $value = trim($params['value']);
+        $format = self::date_getFormat($params['field']->getElement('format'));
+        $field = $params['field']->getName();
+        return self::getDateFilterWhere( $value, $field, $format);
+    }
 
-        // kein Suchtext, kein Filter
+    // allow external call in not-searchform-context
+    // @param   string $value   search criteria
+    // @param   string $field   db-field
+    // @param   string $format  date-format as defined in self::VALUE_DATE_FORMATS
+    // @return  string          WHERE-clause
+    public static function getDateFilterWhere( $value, $field, $format)
+    {
+        // kein Suchtext => kein Filter
         if ($value == '') {
             return '';
         }
 
-        $sql = rex_sql::factory();
-        $format = self::date_getFormat($params['field']->getElement('format'));
-        $field = $params['field']->getName();
-        $field = $sql->escapeIdentifier($field);
+        $field = rex_sql::factory()->escapeIdentifier($field);
 
         // Auswertung über Pattern: <|<=|=|>=|> $value
         $pattern = '/^(?<c>\<=|\<|=|\>=|\>)?\s*' . self::VALUE_SEARCH_PATTERN[$format] . '$/';

--- a/lib/yform/value/date.php
+++ b/lib/yform/value/date.php
@@ -207,6 +207,7 @@ class rex_yform_value_date extends rex_yform_value_abstract
         $value = trim($params['value']);
         $format = self::date_getFormat($params['field']->getElement('format'));
         $field = $params['field']->getName();
+        $field = 't0.' . rex_sql::factory()->escapeIdentifier($field);
         return self::getDateFilterWhere( $value, $field, $format);
     }
 
@@ -222,9 +223,7 @@ class rex_yform_value_date extends rex_yform_value_abstract
             return '';
         }
 
-        $field = rex_sql::factory()->escapeIdentifier($field);
-
-        // Auswertung über Pattern: <|<=|=|>=|> $value
+         // Auswertung über Pattern: <|<=|=|>=|> $value
         $pattern = '/^(?<c>\<=|\<|=|\>=|\>)?\s*' . self::VALUE_SEARCH_PATTERN[$format] . '$/';
         $ok = preg_match( $pattern, $value, $match );
         if( $ok ) {

--- a/lib/yform/value/date.php
+++ b/lib/yform/value/date.php
@@ -14,6 +14,19 @@ class rex_yform_value_date extends rex_yform_value_abstract
     const
         VALUE_DATE_FORMATS = ['DD.MM.YYYY' => 'DD.MM.YYYY', 'YYYY-MM-DD' => 'YYYY-MM-DD', 'DD-MM-YYYY' => 'DD-MM-YYYY', 'MM-DD-YYYY' => 'MM-DD-YYYY', 'YYYY' => 'YYYY', 'MM' => 'MM', 'MM-YYYY' => 'MM-YYYY', 'YYYY-MM' => 'YYYY-MM' ];
 
+    // Um im Suchformular weitergehende Auswertungen zu machen
+    const
+        VALUE_SEARCH_PATTERN = [
+            'DD.MM.YYYY' => '(?:(?<d>\d{1,2}(?=\.\d{1,2}\.))\.)?(?:(?<m>\d{1,2})\.)?(?<y>(?:\d{2}|\d{4})))',
+            'YYYY-MM-DD' => '(?<y>(?:\d{2}|\d{4}))(?:-(?<m>\d{1,2}))?(?:-(?<d>\d{1,2}))?',
+            'DD-MM-YYYY' => '(?:(?<d>\d{1,2}(?=-\d{1,2}-))-)?(?:(?<m>\d{1,2})-)?(?<y>(?:\d{2}|\d{4}))',
+            'MM-DD-YYYY' => '(?:(?<m>\d{1,2})-)?(?:(?<d>\d{1,2})-)?(?<y>(?:\d{2}|\d{4}))',
+            'YYYY'       => '(?<y>(?:\d{2}|\d{4}))',
+            'MM'         => '(?<m>\d{1,2})',
+            'MM-YYYY'    => '(?:(?<m>\d{1,2})-)?(?<y>(?:\d{2}|\d{4}))',
+            'YYYY-MM'    => '(?<y>(?:\d{2}|\d{4}))(?:-(?<m>\d{1,2}))?',
+        ];
+
     public function preValidateAction()
     {
         // if date is unformated
@@ -191,54 +204,130 @@ class rex_yform_value_date extends rex_yform_value_abstract
 
     public static function getSearchFilter($params)
     {
-        // 01/15/2015 - 02/15/2015
-        // >19/11/2015
-        // <19/11/2015
-        // =19/11/2015
-        // 19/11/2015
-        // 19/11/2015-19/12/2015
-        // $value = self::date_convertFromFormatToIsoDate($this->getValue(), self::date_getFormat($this->getElement('format')));
-
         $value = trim($params['value']);
+
+        // kein Suchtext, kein Filter
         if ($value == '') {
-            return;
+            return '';
         }
 
         $sql = rex_sql::factory();
         $format = self::date_getFormat($params['field']->getElement('format'));
-        $format_len = strlen($format);
         $field = $params['field']->getName();
-        $firstchar = substr($value, 0, 1);
+        $field = $sql->escapeIdentifier($field);
 
-        switch ($firstchar) {
-            case '>':
-            case '<':
-            case '=':
-                $date = substr($value, 1);
-                $date = self::date_getFromFormattedDate($date, $format, 'YYYY-MM-DD');
-                return '(' . $sql->escapeIdentifier($field) . ' ' . $firstchar . ' ' . $sql->escape($date) . ')';
-                break;
+        // Auswertung über Pattern: <|<=|=|>=|> $value
+        $pattern = '/^(?<c>\<=|\<|=|\>=|\>)?\s*' . self::VALUE_SEARCH_PATTERN[$format] . '$/';
+        $ok = preg_match( $pattern, $value, $match );
+        if( $ok ) {
+
+            $comparator = $match['c'] ?: '=';
+            $year = $match['y'] ?: null;
+            if( strlen($year) == 2 ) $year = '20' . $year;
+            $month = $match['m'] ?? null;
+            $day = $match['d'] ?? null;
+
+            if( $year != null )
+            {
+                if( $month != null )
+                {
+                    // Abfrage auf ein konkretes Datum YYYY-MM-DD, etc.
+                    if( $day != null )
+                    {
+                        return '( ' . self::createDbDateComparison( $field, $comparator, $year, $month, $day ) . ' )';
+                    }
+
+                    // Abfrage auf YYYY-MM (=)
+                    // =2020-02  -->  2020-02-00 <= db <= 2020-02-99
+                    if( $comparator == '=' )
+                    {
+                        $from = self::createDbDateComparison( $field, '>=', $year, $month, '00' );
+                        $to = self::createDbDateComparison( $field, '<=', $year, $month, '99' );
+                        return "( $from AND $to )";
+                    }
+
+                    // Abfrage auf YYYY-MM (alle übrigen)
+                    // <2020-02   -->  < 2020-02-00
+                    // <=2020-02  -->  < 2020-02-99
+                    // >=2020-02  -->  > 2020-02-00
+                    // >2020-02   -->  > 2020-02-99
+                    $day = ( $comparator == '<' || $comparator == '>=' ) ? '00' : '99';
+                    return '( ' . self::createDbDateComparison( $field, $comparator, $year, $month ) . ' )';
+                }
+
+                // Abfrage auf YYYY
+                return "( YEAR($field) $comparator $year )";
+
+            }
+
+            if ( $month != null )
+            {
+                return "( MONTH($field) $comparator $month )";
+            }
+
         }
 
-        // date
-        if (strlen($value) == $format_len) {
-            $date = self::date_getFromFormattedDate($value, $format, 'YYYY-MM-DD');
-            return '(' . $sql->escapeIdentifier($field) . ' = ' . $sql->escape($date) . ')';
+        // Range-Auswertung über Pattern: $value1 - $value2
+        $pattern2 = str_replace( ['<y>','<m>','<d>'], ['<y2>','<m2>','<d2>'], self::VALUE_SEARCH_PATTERN[$format] );
+        $pattern = '/^'.self::VALUE_SEARCH_PATTERN[$format].'\s* - \s*' . $pattern2 . '$/';
+        $ok = preg_match( $pattern, $value, $match );
+        if( $ok ) {
+
+            $year_from = $match['y'] ?: '';
+            if( strlen($year_from) == 2 ) $year_from = '20' . $year_from;
+            $year_to = $match['y2'] ?: '';
+            if( strlen($year_to) == 2 ) $year_to = '20' . $year_to;
+            $month_from = $match['m'] ?: '00';
+            $month_to = $match['m2'] ?: '99';
+            $day_from = $match['d'] ?: '00';
+            $day_to = $match['d2'] ?: '99';
+
+            if( $format == 'YYYY' )
+            {
+                return "( YEAR($field) >= $year_from AND YEAR($field) <= $year_to )";
+            }
+
+            if( $format == 'MM' )
+            {
+                return "( MONTH($field) >= $month_from AND MONTH($field) <= $month_to )";
+            }
+
+            $from = self::createDbDateComparison( $field, '>=', $year_from, $month_from, $day_from );
+            $to = self::createDbDateComparison( $field, '<=', $year_to, $month_to, $day_to );
+            return "( $from AND $to )";
         }
 
-        $dates = explode(' - ', $value);
-        if (count($dates) == 2) {
-            // daterange
-            $date_from = self::date_getFromFormattedDate($dates[0], $format, 'YYYY-MM-DD');
-            $date_to = self::date_getFromFormattedDate($dates[1], $format, 'YYYY-MM-DD');
+        // ungültige bzw. nicht verwertbare Eingabe ( kein valides SQL möglich )
+        // -> interpretiert als: "kein Satz entspricht dem Kriterium"
+        return '( false )';
 
-            return ' (
-            ' . $sql->escapeIdentifier($field) . '>= ' . $sql->escape($date_from) . ' and
-            ' . $sql->escapeIdentifier($field) . '<= ' . $sql->escape($date_to) . '
-            ) ';
+    }
+
+    // @params string $field        Feldame in Ticks (z.B. `datum`)
+    // @params string $comparator   < | <= | = | >= | >
+    // @params string $year         immer 4 Stellen, durch regex bereits sichergestellt
+    // @params null|string $month   0-2 Stellen, muss aufgefüllt werden
+    // @params null|string $day     0-2 Stellen, muss aufgefüllt werden
+    // @return string               SQL-Such-Term
+    public static function createDbDateComparison( $field, $comparator, $year, $month=null, $day=null )
+    {
+        $len = 0;
+        $value = '';
+        if( $month != null ) {
+            $value = str_pad( $month, 2, '0', STR_PAD_LEFT);
+            $len += 3;
+            if( $day != null ) {
+                $value .= '-' . str_pad( $day, 2, '0', STR_PAD_LEFT);
+                $len += 3;
+            }
         }
-
-        // wenn alles nicht hilfe -> plain rein
-        return '(' . $sql->escapeIdentifier($field) . ' = ' . $sql->escape($value) . ')';
+        if( $len ) {
+            $len += 4;
+            if( $len == 10 ) {
+                return "CAST($field AS CHAR) $comparator '$year-$value'";
+            }
+            return "SUBSTR($field,1,$len) $comparator '$year-$value'";
+        }
+        return "YEAR($field) $comparator $year";
     }
 }

--- a/lib/yform/value/date.php
+++ b/lib/yform/value/date.php
@@ -17,7 +17,7 @@ class rex_yform_value_date extends rex_yform_value_abstract
     // Um im Suchformular weitergehende Auswertungen zu machen
     const
         VALUE_SEARCH_PATTERN = [
-            'DD.MM.YYYY' => '(?:(?<d>\d{1,2}(?=\.\d{1,2}\.))\.)?(?:(?<m>\d{1,2})\.)?(?<y>(?:\d{2}|\d{4})))',
+            'DD.MM.YYYY' => '(?:(?<d>\d{1,2}(?=\.\d{1,2}\.))\.)?(?:(?<m>\d{1,2})\.)?(?<y>(?:\d{2}|\d{4}))',
             'YYYY-MM-DD' => '(?<y>(?:\d{2}|\d{4}))(?:-(?<m>\d{1,2}))?(?:-(?<d>\d{1,2}))?',
             'DD-MM-YYYY' => '(?:(?<d>\d{1,2}(?=-\d{1,2}-))-)?(?:(?<m>\d{1,2})-)?(?<y>(?:\d{2}|\d{4}))',
             'MM-DD-YYYY' => '(?:(?<m>\d{1,2})-)?(?:(?<d>\d{1,2})-)?(?<y>(?:\d{2}|\d{4}))',


### PR DESCRIPTION
Betrifft Issue #860. Da wird beschrieben, dass eine Eingabe im Suchfenster zu einer ungültigen SQL-Afrage führt, die nicht abgefangen wird. Die Änderungen betreffen die Methode `getSearchFilter`, die den fehler baut. Mit den Änderungen wird erreicht:
* Ungültige Eingaben werden zu `WHERE FALSE`, somit ist der SQL-Fehler vermieden
* Zusätzlich wurden die Auswertungsmöglichkeiten durch flexiblere Suchbegriffseingabe verbessert 
* Eingaben dürfen etwas laxer sein, was die Leerzeichen anbelangt.

Die Änderungen im Detail:
* Bei allen Eingaben dürfen die Elemente DD und MM jetzt auch 1-stellig eingegeben werden ( 01 und 1 sind gleichwertig)
* bei allen Eingaben darf das Element YYYY jetzt auch 2-stellig eingegeben werden. 2-stellige Jahreszahlen werden um 20 ergänzt (19 und 2019 sind gleichwertig)
* In zusammengesetzten Datumsformaten können Details weggelassen werden. Beispiel: für ein Datum im Format DD.MM.YYYY sind auch MM.YYYY und YYYY zulässig. Je nach Vergleichsoperator werden die Such-Terms entsprechend aufgebaut. "> 03.2019" würde alle Datumsangaben erfassen, die nach "2019-03-99 liegen. Und "<=3.19" löst eine Suche nach Werten vor "2019-03-00" aus.
* Zulässig ist immer das Format des Feldes. Beispiel: MM-YYYY. Dann darf nach Eingaben der Formate MM-YYYY und YYYY gesucht werden. Eingaben der Form DD-MM-YYYY ergeben einen Fehler.
* Fehlerhafte Eingaben bedeuten "nicht in der Tabelle gefunden" und resultieren im Such-Term `( false )` - und damit einem leeren Suchergebnis (analog zu Textfeldern wenn der Begriff nicht vorkommt).

-----
Nachtrag 10.05.2020: Die Where-Klausel aufzubauen ist in eine von außen statisch aufzurufende Methode ausgelagert. Dadurch kann die Methode in ganz anderen Zusammenhängen genutzt werden, z.B. mit YORM-Queries:
```php
$filter = ' < 4.20'; # suche alles vor 01.04.2020
myDataset::query()
    ->whereRaw( rex_yform_value_date::getDateFilterWhere( $filter,'datum','DD.MM.YYYY') )
    ->find();
```