### PR TITLE
Create .gitignore.example

### DIFF
--- a/.gitignore.example
+++ b/.gitignore.example
@@ -1,0 +1,2 @@
+# copy this line to /.gitignore of your REDAXO root
+redaxo/data/addons/yform/plugins/manager/upload/*


### PR DESCRIPTION
Uploads aus git ausschließen. Ich nehme an, es gehört hier hin - aber eigentlich würde ich es lieber im REDAXO-Repo sehen.