### PR TITLE
added notice for "empty" validation

### DIFF
--- a/lib/yform/validate/empty.php
+++ b/lib/yform/validate/empty.php
@@ -46,7 +46,7 @@ class rex_yform_validate_empty extends rex_yform_validate_abstract
             'name' => 'empty',
             'values' => [
                 'name' => ['type' => 'select_names', 'multiple' => true, 'label' => rex_i18n::msg('yform_validate_empty_name'), 'notice' => rex_i18n::msg('yform_validate_empty_notices_name')],
-                'message' => ['type' => 'text',        'label' => rex_i18n::msg('yform_validate_empty_message')],
+                'message' => ['type' => 'text',        'label' => rex_i18n::msg('yform_validate_empty_message'), 'notice' => rex_i18n::msg('translatable')],
             ],
             'description' => rex_i18n::msg('yform_validate_empty_description'),
             'famous' => true,


### PR DESCRIPTION
in der REDAXOhour wurde erwähnt dass man an dieser stelle mehrsprachig arbeiten kann.

**ich vermute** das geht mit dem regulären translate prefix... daher an dieser stelle auch die Notiz einblenden, die wir im core überall an solchen feldern haben

![grafik](https://user-images.githubusercontent.com/120441/81466556-ef2bb480-91d2-11ea-9315-acb679fc3489.png)
