### PR TITLE
Attribute für PRIO-Feld

### DIFF
--- a/plugins/manager/lib/yform/value/prio.php
+++ b/plugins/manager/lib/yform/value/prio.php
@@ -95,6 +95,7 @@ class rex_yform_value_prio extends rex_yform_value_abstract
                 'fields' => ['type' => 'select_names', 'label' => rex_i18n::msg('yform_values_prio_fields')],
                 'scope' => ['type' => 'select_names', 'label' => rex_i18n::msg('yform_values_prio_scope')],
                 'default' => ['type' => 'choice',       'label' => rex_i18n::msg('yform_values_prio_default'), 'choices' => [1 => 'Am Anfang', '' => 'Am Ende']],
+                'attributes' => ['type' => 'text',    'label' => rex_i18n::msg('yform_values_defaults_attributes'), 'notice' => rex_i18n::msg('yform_values_defaults_attributes_notice')],
                 'notice' => ['type' => 'text',        'label' => rex_i18n::msg('yform_values_defaults_notice')],
             ],
             'description' => rex_i18n::msg('yform_values_prio_description'),


### PR DESCRIPTION
Ermöglicht u.a. auch die Aktivierung der Live-Suche mittels
`{"class": "form-control selectpicker","data-live-search": "true"}`

closes: https://github.com/yakamara/redaxo_yform/issues/682

Vorher: 
<img width="550" alt="Bildschirmfoto 2020-05-21 um 11 14 36" src="https://user-images.githubusercontent.com/791247/82544677-c94ccb00-9b55-11ea-92d3-58750c99fb6b.png">

Nachher: 
<img width="538" alt="Bildschirmfoto 2020-05-21 um 11 19 41" src="https://user-images.githubusercontent.com/791247/82544701-d2d63300-9b55-11ea-9540-a45cab38238b.png">
