### PR TITLE
showvalue - varchar erlauben

### DIFF
--- a/lib/yform/value/showvalue.php
+++ b/lib/yform/value/showvalue.php
@@ -39,7 +39,7 @@ class rex_yform_value_showvalue extends rex_yform_value_abstract
                 'notice' => ['type' => 'text',    'label' => rex_i18n::msg('yform_values_defaults_notice')],
             ],
             'description' => rex_i18n::msg('yform_values_showvalue_description'),
-            'db_type' => ['text'],
+            'db_type' => ['text', 'varchar(191)'],
         ];
     }
 


### PR DESCRIPTION
@dergel ich brauche das gerade, da auf dem Feldtyp ein Index der Datenbank liegt und das geht nicht mit `text`. Hätte es deswegen in der 3.4 drin.

Hoffe, das war's jetzt an Störungen von mir ;)