### PR TITLE
remove superflous headline

### DIFF
--- a/docs/yorm.md
+++ b/docs/yorm.md
@@ -1,7 +1,5 @@
 # YOrm ORM
 
-## Mini-ORM für YForm
-
 (ORM = Object-relational mapping = Objektrelationale Abbildung)
 
 YOrm erleichtert den Umgang mit in YForm Table Manager angemeldeten Tabellen und deren Daten. So ist es möglich mittels eigener Modelclasses die Daten zu verarbeiten und aufbereitet auszugeben. Werden im Table Manager neue Felder hinzugefügt oder entfernt, passen sich über YOrm ausgegegebene Formulare sofort darauf an. Die übliche PIPE oder PHP-Programmierung entfällt. Formulare müssen meist nur durch wenige Parameter ergänzt werden um sofort zu funktionieren.


### PR DESCRIPTION
für mich sind hier zu viele überschriften.. inbesondere liefern die 2 headlines keinen inhaltlichen mehrwert, da sie im großteil sich gegenseitig wiederholen (mit fachwörtern die viele redaxo user gar nicht kennen -> es schreckt ab).

habe eine in meinen Augen überflüssige entfernt

Vorher:

![image](https://user-images.githubusercontent.com/47448731/82878534-e7427300-9f3b-11ea-9315-fb6472da35c7.png)


Nachher:

![image](https://user-images.githubusercontent.com/47448731/82878555-ee698100-9f3b-11ea-88c4-8f4c432da07c.png)
