### PR TITLE
php extension mbstring ist erforderlich

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -58,6 +58,7 @@ requires:
     redaxo: '^5.8.0'
     php:
         version: '^7.0'
+        extensions: [mbstring]
 
 system_plugins:
     - manager


### PR DESCRIPTION
Siehe z.b. Hier https://github.com/yakamara/redaxo_yform/blob/05619937c71a489ba76c9b9cc88dcb04b1e15ffe/lib/yform/validate/customfunction.php#L23

Ggf. Sind noch weitere notwendig, hab ich nicht im detail untersucht