### PR TITLE
Style von Beispielen im Formbuilder verbessern

### DIFF
--- a/assets/yform-formbuilder.css
+++ b/assets/yform-formbuilder.css
@@ -60,6 +60,10 @@ table.yform-table-help tr.yform-classes-famous .btn-default {
     border-color: #a1a9b4
 }
 
+table.yform-table-help tr.yform-classes-famous .example-code {
+    display: inline-block;
+}
+
 table.yform-table-help tr.yform-classes-deprecated {
     background: #f1a9b4;
 }

--- a/lib/yform.php
+++ b/lib/yform.php
@@ -669,7 +669,7 @@ class rex_yform
                         $definitions = $class->getDefinitions();
                         $definition_desc = $definitions['description'] ?? '';
                         if ('' != $desc) {
-                            $desc = '<code>' . $desc . '</code>';
+                            $desc = '<code class="example-code">' . nl2br($desc) . '</code>';
                         }
                         if ('' != $definition_desc) {
                             $desc = $definition_desc . '<br />' . $desc;


### PR DESCRIPTION
- New line zu `<br>` umschreiben in Beispielen
- Code als inline-block darstellen

Links:
- Löst folgendes Problem: https://friendsofredaxo.slack.com/archives/C1BAXLN2F/p1597916533016100?thread_ts=1597916043.014600&cid=C1BAXLN2F
- Tritt auf da New Line nicht angezeigt wird mit dem aktuellen CSS: https://github.com/yakamara/redaxo_yform/blob/dec5f746d4945ca240daf3c6499fd9df68f1e78c/lib/yform/value/hidden.php#L42