### PR TITLE
Adds EP to overwrite History user

### DIFF
--- a/plugins/manager/lib/yform/manager/dataset.php
+++ b/plugins/manager/lib/yform/manager/dataset.php
@@ -611,6 +611,8 @@ class rex_yform_manager_dataset
         if ('backend' == $user && rex::getUser()) {
             $user = rex::getUser()->getLogin();
         }
+        // ep to overwrite user
+        $user = rex_extension::registerPoint(new rex_extension_point('YFORM_HISTORY_USER', $user));
 
         $sql = rex_sql::factory();
         $sql->setDebug(self::$debug);

--- a/plugins/manager/lib/yform/manager/dataset.php
+++ b/plugins/manager/lib/yform/manager/dataset.php
@@ -612,7 +612,7 @@ class rex_yform_manager_dataset
             $user = rex::getUser()->getLogin();
         }
         // ep to overwrite user
-        $user = rex_extension::registerPoint(new rex_extension_point('YFORM_HISTORY_USER', $user));
+        $user = rex_extension::registerPoint(new rex_extension_point('YCOM_HISTORY_USER', $user));
 
         $sql = rex_sql::factory();
         $sql->setDebug(self::$debug);


### PR DESCRIPTION
fixes: https://github.com/yakamara/redaxo_yform/issues/950


Class into /lib - folder of project addon

```php 
class my_ycom {
    public static function getTheUser() {
        $ycom_user = rex_ycom_auth::getUser();
        $subject = rex_ycom_auth::getUser()->getValue('login');
        return $subject ;
    }
}
```

Example for project boot.php

```php
rex_extension::register('PACKAGES_INCLUDED', static function () {
	if(!rex::isBackend() && rex_ycom_auth::getUser())
	{
		rex_extension::register('YCOM_HISTORY_USER', 'my_ycom::getTheUser');   
	}
});
```