### PR TITLE
count() mit group_by verwenden

### DIFF
--- a/plugins/manager/lib/yform/manager/query.php
+++ b/plugins/manager/lib/yform/manager/query.php
@@ -737,15 +737,10 @@ class rex_yform_manager_query implements IteratorAggregate, Countable
      * @return int
      */
     public function count()
-    {
+    {        
         $query = clone $this;
-        $query
-            ->resetSelect()
-            ->selectRaw('COUNT(*)', 'count')
-            ->resetOrderBy();
-
         $sql = rex_sql::factory();
-        $sql->setQuery($query->getQuery(), $query->getParams());
+        $sql->setQuery('SELECT COUNT(*) AS count FROM (' . $query->getQuery() . ') AS __SUBQUERY', $query->getParams());
 
         return $sql->getValue('count');
     }


### PR DESCRIPTION
habe gerade das Problem dass count() in Kombination mit einem Group BY statement nicht funktioniert; ich erhalte einen SQL Fehler weil ich nach Spalte gruppiere welche im Select Statement generiert wird.
Habe für mich ein Lösung gefunden: man kann die originale Query einfach als Subquery ausführen. Hattet ihr das bereits bedacht? Kann es da zu Problemen führen die ich gerade nicht sehe? in meinem Fall funktioniert es wunderbar