### PR TITLE
simply use `strtoupper` instead of the mb-ext equivalent

### DIFF
--- a/plugins/manager/lib/yform/manager/query.php
+++ b/plugins/manager/lib/yform/manager/query.php
@@ -444,7 +444,7 @@ class rex_yform_manager_query implements IteratorAggregate, Countable
      */
     public function whereNested($nested, $operator = 'AND')
     {
-        $operator = mb_strtoupper(trim($operator));
+        $operator = strtoupper(trim($operator));
 
         if (is_array($nested)) {
             $this->where[] = $this->buildNestedWhere($nested, $operator);


### PR DESCRIPTION
the only valid strings for this var are `AND` or `OR`, so no multibyte-magic involved