### PR TITLE
Neuer EP YFORM_DATA_LIST_LINKS hinzugefügt

### DIFF
--- a/plugins/manager/lib/yform/manager.php
+++ b/plugins/manager/lib/yform/manager.php
@@ -544,6 +544,7 @@ class rex_yform_manager
                     ]
                     );
                 } else {
+
                     // to take care, that db field are not in conflict with th names, ' ' have been added to identifier
 
                     $list->addColumn(rex_i18n::msg('yform_function').' ', '<i class="rex-icon rex-icon-edit"></i> ' . rex_i18n::msg('yform_edit'));
@@ -569,6 +570,7 @@ class rex_yform_manager
                     }
 
                     $list->setColumnLayout(rex_i18n::msg('yform_function').' ', ['<th class="rex-table-action" colspan="'.$colspan.'">###VALUE###</th>', '<td class="rex-table-action">###VALUE###</td>']);
+
                 }
 
                 $list = rex_extension::registerPoint(new rex_extension_point('YFORM_DATA_LIST', $list, ['table' => $this->table]));
@@ -670,13 +672,6 @@ class rex_yform_manager
                     $item['attributes']['class'][] = 'btn-default';
                     $table_links[] = $item;
                 }
-                if (count($table_links) > 0) {
-                    $fragment = new rex_fragment();
-                    $fragment->setVar('size', 'xs', false);
-                    $fragment->setVar('buttons', $table_links, false);
-                    $panel_options .= '<small class="rex-panel-option-title">' . rex_i18n::msg('yform_table') . '</small> ' . $fragment->parse('core/buttons/button_group.php');
-                }
-
                 $field_links = [];
                 if (!$popup && rex::getUser()->isAdmin()) {
                     $item = [];
@@ -684,6 +679,19 @@ class rex_yform_manager
                     $item['url'] = 'index.php?page=yform/manager/table_field&table_name=' . $this->table->getTableName();
                     $item['attributes']['class'][] = 'btn-default';
                     $field_links[] = $item;
+                }
+                ['table_links' => $table_links, 'field_links' => $field_links] = rex_extension::registerPoint(
+                    new rex_extension_point(
+                        'YFORM_DATA_LIST_LINKS',
+                        ['table_links' => $table_links, 'field_links' => $field_links],
+                        ['table' => $this->table, 'popup' => $popup]
+                    )
+                );
+                if (count($table_links) > 0) {
+                    $fragment = new rex_fragment();
+                    $fragment->setVar('size', 'xs', false);
+                    $fragment->setVar('buttons', $table_links, false);
+                    $panel_options .= '<small class="rex-panel-option-title">' . rex_i18n::msg('yform_table') . '</small> ' . $fragment->parse('core/buttons/button_group.php');
                 }
                 if (count($field_links) > 0) {
                     $fragment = new rex_fragment();


### PR DESCRIPTION
Vorschlag für einen neuen EP. In der *manager.php* wird ja u.a die Liste zusammengestellt. Dabei werden je nach Parametrisierung und User-Context (isAdmin) auch Buttons in die Titelteile der Datentabelle geschrieben. Ich hab vermisst, dort auch mit einfachen Mitteln eigene Button einzubauen. Z.B. eine Funktion einzuhängen, die mir auf Klick die Tabelle beim Testen wieder in einen Basiszustand zurückversetzt. Ja, kann man evtl. auch per YFORM_DATA_LIST_GRID hinbekommen, ist aber nicht so schön.

![grafik](https://user-images.githubusercontent.com/10065904/108097952-17f6a980-7083-11eb-949f-81f7e4441a1f.png)

Dazu müsste die Reihenfolge der Bearbeitungsschritte etwas umgestellt und der EP-Aufruf hinzugefügt werden. Bisher ist die Abfolge

-    Erstelle die $table_links
-    Ausgabe der $table_links
-    Erstelle die $field_links
-    Ausgabe der $field_links

Was ich geändert habe in

-    Erstelle die $table_links
-    Erstelle die $field_links
-    schicke beide durch den EP "YFORM_DATA_LIST_LINKS"
-    Ausgabe der $table_links
-    Ausgabe der $field_links

ich hab das hier bei mir im Einsatz (aktuelles REX und YFORM), läuft klaglos.


