### PR TITLE
Tabellennamen für Export und Edit-Liste optimiert

### DIFF
--- a/plugins/manager/boot.php
+++ b/plugins/manager/boot.php
@@ -33,7 +33,7 @@ if (rex::isBackend() && rex::getUser()) {
     $prio = 1;
     foreach ($tables as $table) {
         if ($table->isActive() && rex::getUser()->getComplexPerm('yform_manager_table')->hasPerm($table->getTableName())) {
-            $be_page = new rex_be_page_main('yform_tables', $table->getTableName(), rex_i18n::translate($table->getName()));
+             $be_page = new rex_be_page_main('yform_tables', $table->getTableName(), $table->getNameLocalized() );
             $be_page->setHref('index.php?page=yform/manager/data_edit&table_name=' . $table->getTableName());
             $be_page->setIcon('rex-icon rex-icon-module');
             $be_page->setPrio($prio);

--- a/plugins/manager/lib/yform/manager.php
+++ b/plugins/manager/lib/yform/manager.php
@@ -137,7 +137,7 @@ class rex_yform_manager
         echo rex_extension::registerPoint(
             new rex_extension_point(
                 'YFORM_MANAGER_DATA_PAGE_HEADER',
-                rex_view::title(rex_i18n::msg('yform_table') . ': ' . rex_i18n::translate($this->table->getName()) . ' <small>[' . $this->table->getTablename() . ']' . $description . '</small>', ''),
+                rex_view::title(rex_i18n::msg('yform_table') . ': ' . $this->table->getNameLocalized() . ' <small>[' . $this->table->getTablename() . ']' . $description . '</small>', ''),
                 [
                     'yform' => $this,
                 ]
@@ -824,7 +824,7 @@ class rex_yform_manager
 
         $table = $this->table;
 
-        $table_info = '<b>' . rex_i18n::translate($table->getName()) . ' [<a href="index.php?page=yform/manager/table_edit&start=0&table_id='.$table->getId().'&func=edit">' . $table->getTableName() . '</a>]</b> ';
+        $table_info = '<b>' . $table->getNameLocalized() . ' [<a href="index.php?page=yform/manager/table_edit&start=0&table_id='.$table->getId().'&func=edit">' . $table->getTableName() . '</a>]</b> ';
         echo rex_view::info($table_info);
 
         $_csrf_key = 'table_field-'.$table->getTableName();

--- a/plugins/manager/lib/yform/manager/table.php
+++ b/plugins/manager/lib/yform/manager/table.php
@@ -117,6 +117,16 @@ class rex_yform_manager_table implements ArrayAccess
         return $this->values['name'];
     }
 
+    public function getNameLocalized()
+    {
+        $table_name = $this->getTableName();
+        $name = $this->getName();
+        if( $name === $table_name ) {
+            $name = 'translate:'.$table_name;
+        }
+        return \rex_i18n::translate($name);
+    }
+    
     public function getId()
     {
         return $this->values['id'];

--- a/plugins/manager/lib/yform/manager/table.php
+++ b/plugins/manager/lib/yform/manager/table.php
@@ -121,8 +121,12 @@ class rex_yform_manager_table implements ArrayAccess
     {
         $table_name = $this->getTableName();
         $name = $this->getName();
-        if( $name === $table_name ) {
-            $name = 'translate:'.$table_name;
+        if ($name === $table_name) {
+            $name = 'translate:'.$name;
+        }
+        $name = rex_i18n::translate($name);
+        if (preg_match ('/^\[translate:(.*?)\]$/',$name, $match)) {
+            $name = $match[1];
         }
         return \rex_i18n::translate($name);
     }

--- a/plugins/manager/pages/table_edit.php
+++ b/plugins/manager/pages/table_edit.php
@@ -325,11 +325,15 @@ if ($show_list && rex::getUser()->isAdmin()) {
 
     $list->setColumnLabel('name', rex_i18n::msg('yform_manager_name').' / '.rex_i18n::msg('yform_manager_table_name'));
     $list->setColumnFormat('name', 'custom', static function ($params) {
-        $name = $params['list']->getValue('name');
-        if ($name === $params['value']) {
+        $name = $params['value'];
+        if ($name === $params['list']->getValue('table_name')) {
             $name = 'translate:'.$name;
         }
-        return rex_i18n::translate($name).' [###table_name###]<p><a href="index.php?page=yform/manager/data_edit&table_name=###table_name###"><i class="rex-icon rex-icon-edit"></i> '.rex_i18n::msg('yform_edit_datatable').'</a></p>';
+        $name = rex_i18n::translate($name);
+        if (preg_match ('/^\[translate:(.*?)\]$/',$name, $match)) {
+            $name = $match[1];
+        }
+        return $name.' [###table_name###]<p><a href="index.php?page=yform/manager/data_edit&table_name=###table_name###"><i class="rex-icon rex-icon-edit"></i> '.rex_i18n::msg('yform_edit_datatable').'</a></p>';
     });
 
     $list->setColumnLabel('status', rex_i18n::msg('yform_manager_table_status'));

--- a/plugins/manager/pages/table_edit.php
+++ b/plugins/manager/pages/table_edit.php
@@ -325,7 +325,11 @@ if ($show_list && rex::getUser()->isAdmin()) {
 
     $list->setColumnLabel('name', rex_i18n::msg('yform_manager_name').' / '.rex_i18n::msg('yform_manager_table_name'));
     $list->setColumnFormat('name', 'custom', static function ($params) {
-        return rex_i18n::translate($params['value']).' [###table_name###]<p><a href="index.php?page=yform/manager/data_edit&table_name=###table_name###"><i class="rex-icon rex-icon-edit"></i> '.rex_i18n::msg('yform_edit_datatable').'</a></p>';
+        $name = $params['list']->getValue('name');
+        if ($name === $params['value']) {
+            $name = 'translate:'.$name;
+        }
+        return rex_i18n::translate($name).' [###table_name###]<p><a href="index.php?page=yform/manager/data_edit&table_name=###table_name###"><i class="rex-icon rex-icon-edit"></i> '.rex_i18n::msg('yform_edit_datatable').'</a></p>';
     });
 
     $list->setColumnLabel('status', rex_i18n::msg('yform_manager_table_status'));

--- a/plugins/manager/pages/table_edit.php
+++ b/plugins/manager/pages/table_edit.php
@@ -377,7 +377,7 @@ if (!rex::getUser()->isAdmin()) {
     foreach ($tables as $table) {
         if ($table->isActive() && !$table->isHidden() && (rex::getUser()->isAdmin() || rex::getUser()->hasPerm($table->getPermKey()))) {
             echo '<li><a href="index.php?page=yform/manager/data_edit&table_name=' . $table->getTableName() . '">' . $table->getNameLocalized() . '</a></li>';
-       }
+        }
     }
 
     echo '</ul></div>';

--- a/plugins/manager/pages/table_edit.php
+++ b/plugins/manager/pages/table_edit.php
@@ -376,8 +376,8 @@ if (!rex::getUser()->isAdmin()) {
     $tables = rex_yform_manager_table::getAll();
     foreach ($tables as $table) {
         if ($table->isActive() && !$table->isHidden() && (rex::getUser()->isAdmin() || rex::getUser()->hasPerm($table->getPermKey()))) {
-            echo '<li><a href="index.php?page=yform/manager/data_edit&table_name=' . $table->getTableName() . '">' . rex_i18n::translate($table->getName()) . '</a></li>';
-        }
+            echo '<li><a href="index.php?page=yform/manager/data_edit&table_name=' . $table->getTableName() . '">' . $table->getNameLocalized() . '</a></li>';
+       }
     }
 
     echo '</ul></div>';

--- a/plugins/manager/pages/tableset_export.php
+++ b/plugins/manager/pages/tableset_export.php
@@ -15,13 +15,7 @@ $page = rex_request('page', 'string', '');
 $yform_tables = [];
 foreach (rex_yform_manager_table::getAll() as $g_table) {
     $table_name = $g_table->getTableName();
-    
-    $name = $g_table->getName();
-    if( $name === $table_name ) {
-        $name = 'translate:'.$table_name;
-    }
-    
-    $yform_tables[$table_name] = rex_i18n::translate($name).' ['.$table_name.']';
+    $yform_tables[$table_name] = rex_i18n::translate($g_table->getNameLocalized()).' ['.$table_name.']';
 }
 
 $yform = new rex_yform();

--- a/plugins/manager/pages/tableset_export.php
+++ b/plugins/manager/pages/tableset_export.php
@@ -15,12 +15,13 @@ $page = rex_request('page', 'string', '');
 $yform_tables = [];
 foreach (rex_yform_manager_table::getAll() as $g_table) {
     $table_name = $g_table->getTableName();
-
-    if ('[translate:'.$table_name.']' != rex_i18n::msg($table_name)) {
-        $table_name = rex_i18n::msg($table_name);
+    
+    $name = $g_table->getName();
+    if( $name === $table_name ) {
+        $name = 'translate:'.$table_name;
     }
-
-    $yform_tables[$g_table->getTableName()] = $table_name.' ['.$g_table->getTableName().']';
+    
+    $yform_tables[$table_name] = rex_i18n::translate($name).' ['.$table_name.']';
 }
 
 $yform = new rex_yform();


### PR DESCRIPTION
Kein großes Ding, aber die Berechnung des Labels (rotes Oval) ist uneinheitlich.

In der Auflistung der Tabellen für den Export wird nur der *table_name* (z.B. rex_tabelle) angezeigt, es sei denn es gibt einen .lang-Eintrag  `rex_tabelle = Label`. Der eigentliche Tabellennamen (Feld *name*) wird ignoriert.

In der Editierliste ist es genau anders; es wird ausschließlich der Wert im Feld name* ("Beschreibung") herangezogen. Das ist plausibel, da es ein Pflichtfeld ist, aber Inghalt ist eben oft nur der Tabellennamen (z.B. rex_tabelle). Der wird dann aber mangels führendem `translate:`nicht via .lang-Eintrag übersetzt. 

|  table_edit | table_export  | Seitenleiste |
| --- | --- | --- |
|![grafik](https://user-images.githubusercontent.com/10065904/108703921-9207b200-750b-11eb-8c94-27e36078cb08.png)|![grafik](https://user-images.githubusercontent.com/10065904/108704036-bbc0d900-750b-11eb-922e-a30f54232b21.png)|![grafik](https://user-images.githubusercontent.com/10065904/108741872-70242480-7537-11eb-854d-44c155f8a819.png)|

Im PR sind ist beiden PHP-Dateien der Code auf folgende Logik geändert:

1. Rufe die Tabellenbeschreibung ab
2. Falls die Tabellenbechreibung identisch mit dem Tabellennamen ist, setze `translate:` davor
3. Rufe den Namen mit rex_i18n::translate ab.

Damit sind alle Fälle abwärtskompatibel abgedeckt:

- einfacher Text ("Label") wird als Text ausgegeben
- .lang-Referenz ("translate:label_of_tabelle") wird übersetzt
- Tabellenname ("rex_tabelle"), zu dem es einen .lang-Eintrag gibt `rex_tabelle = Label`, wird entsprechend übersetzt 
- Tabellenname ("rex_tabelle") ohne .lang-Eintrag gibt den Tabellennamen aus.

In *table_edit.php* muss man die Umsetzung "manuell" machen, an anderen Stellen geht es per neuer Methode *rex_yform_manager_table->getNameLocalized()*. Wenn ich noch mehr Stellen finde, die man auf die Methode ändern könnte, packe ich sie in den PR.