### PR TITLE
Doppeltes Semikolon entfernt

### DIFF
--- a/docs/yorm.md
+++ b/docs/yorm.md
@@ -81,7 +81,7 @@ $items = MyTable::query()
 $item = MyTable::create()
               ->setValue('user_id', 5)
               ->setValue('article_id', 6)
-              ->save();;
+              ->save();
 ```
 
 ```php


### PR DESCRIPTION
Doppeltes Semikolon entfernt bei: $item = MyTable::create()->setValue('user_id', 5)->setValue('article_id', 6)->save();