### PR TITLE
version bump 3.5.0 Update package.yml 

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: yform
-version: '3.4.1'
+version: '3.5.0-dev'
 author: 'Jan Kristinus, Gregor Harlan'
 supportpage: 'https://github.com/yakamara/redaxo_yform/issues'
 


### PR DESCRIPTION
um nach der Installation der github-version auch nach Wochen noch zu erkennen, dass es sich nicht um einen offiziellen Release handelte.