### PR TITLE
number-Feld mit number-spezifischen input-Attributen

### DIFF
--- a/lib/yform/value/number.php
+++ b/lib/yform/value/number.php
@@ -26,8 +26,7 @@ class rex_yform_value_number extends rex_yform_value_abstract
                 $this->params['form_output'][$this->getId()] = $this->parse(['value.number-view.tpl.php', 'value.integer-view.tpl.php', 'value.view.tpl.php'], ['prepend' => $this->getElement('unit')]);
 
             } else {
-                $this->params['form_output'][$this->getId()] = $this->parse(['value.number.tpl.php', 'value.integer.tpl.php', 'value.text.tpl.php'], ['prepend' => $this->getElement('unit')]);
-
+                $this->params['form_output'][$this->getId()] = $this->parse(['value.number.tpl.php', 'value.integer.tpl.php', 'value.text.tpl.php'], ['type' => 'number', 'attributes' =>  ['max' => '100000', 'step' => '0.01'], 'prepend' => $this->getElement('unit')]);
             }
         }
 
@@ -57,6 +56,8 @@ class rex_yform_value_number extends rex_yform_value_abstract
                 'unit' => ['type' => 'text',    'label' => rex_i18n::msg('yform_values_defaults_unit')],
                 'notice' => ['type' => 'text',    'label' => rex_i18n::msg('yform_values_defaults_notice')],
                 'attributes' => ['type' => 'text',    'label' => rex_i18n::msg('yform_values_defaults_attributes'), 'notice' => rex_i18n::msg('yform_values_defaults_attributes_notice')],
+                'widget' => ['type' => 'choice', 'label' => rex_i18n::msg('yform_values_defaults_widgets'), 'choices' => ['input:text' => 'input:text', 'input:number' => 'input:number'], 'default' => 'input:number'],
+
             ],
             'validates' => [
                 ['type' => ['name' => 'precision', 'type' => 'integer', 'message' => rex_i18n::msg('yform_values_number_error_precision', '1', '65'), 'not_required' => false]],


### PR DESCRIPTION
Ich würde gerne hier die Möglichkeit schaffen, ein Widget auszuwählen bzw. die Parameter PRECISION und SCALE in input-Attribute `max` und `step` für das Textfeld übersetzen - so, wie es beim Date-Feld gemacht wird (`input:date`, `input:text`)

Ich sehe hier im Code aber, dass es bereits wohl ein Number-Template und Integer-Template gibt - diese scheinen jedoch nicht von Haus aus in YForm dabei zu sein. Deswegen habe ich den PR erstmal abgebrochen, um zu wissen, wie ich vorgehen soll.

Meine Idee für die Number-Attribute:

`max="10^(PRECISION - SCALE)"`, z.B. `max="1000"` für `(PRECISION=5)-(SCALE=2)`
`step="1/10^SCALE"`, z.B. `0.01` für `SCALE=2`