### PR TITLE
YF4beta2: Alias hinzufügen

### DIFF
--- a/plugins/manager/lib/list.php
+++ b/plugins/manager/lib/list.php
@@ -149,7 +149,7 @@ class rex_yform_list implements rex_url_provider_interface
         }
 
         // TODO: Performance
-        $this->rows = count($this->query->findValues('id'));
+        $this->rows = count($this->query->findValues($this->query->getTableAlias().'.id'));
         $this->pager->setRowCount($this->rows);
 
         $rowsPerPage = $this->pager->getRowsPerPage();

--- a/plugins/manager/lib/yform/manager/query.php
+++ b/plugins/manager/lib/yform/manager/query.php
@@ -591,7 +591,7 @@ class rex_yform_manager_query implements IteratorAggregate, Countable
 
         if (!$this->orderBy && !$this->orderByResetted) {
             $table = $this->getTable();
-            $this->orderBy($table->getSortFieldName(), $table->getSortOrderName());
+            $this->orderBy($this->getTableAlias().'.'.$table->getSortFieldName(), $table->getSortOrderName());
         }
 
         if ($this->orderBy) {


### PR DESCRIPTION
Wie in Issue #1070 diskutiert muss der Alias hinzugefügt werden, um bei Queries mit Join-Anteilen automatisch eingefügte Felder (meist 'id') eindeutig zu machen.

Details und warum es auffiel stehen im Issue. Betrifft die neue Klasse rex_yform_list und die Klasse rex_yform_manager_query 