### PR TITLE
YF4beta2: Fehlender Alias im Manager ergänzt

### DIFF
--- a/plugins/manager/lib/yform/manager.php
+++ b/plugins/manager/lib/yform/manager.php
@@ -155,7 +155,7 @@ class rex_yform_manager
         if ($data_id > 0) {
             $data_query = $this->table->query()
                 ->alias('t0')
-                ->where('id', $data_id);
+                ->where('t0.id', $data_id);
             $data_query = $this->getDataListQuery($data_query, array_merge($rex_yform_filter, $rex_yform_set), $searchObject);
             $data_collection = $data_query->find();
 


### PR DESCRIPTION
Aufgefallen bei Joins über den neuen EP YFORM_DATA_LIST_QUERY: Das Feld "id" muss eindeutig gemacht werden über den Alias. Da Instanzen von rex_yform_manager_query in Where-Statements den Alias aus gutem Grunde nicht automatisch hinzufügen, muss der Alias ausdrücklich im `->where` angegeben werden. Sieht so aus als ob es nur diese eine Stelle im Manager ist, an der so eine Situation entsteht.