### PR TITLE
YOrm-Query: leftJoinRelation

### DIFF
--- a/plugins/manager/lib/yform/manager/query.php
+++ b/plugins/manager/lib/yform/manager/query.php
@@ -188,7 +188,7 @@ class rex_yform_manager_query implements IteratorAggregate, Countable
         $relatedTable = $alias ?: $relation['table'];
 
         if (4 == $relation['type'] || 5 == $relation['type']) {
-            return $this->join($relation['table'], $alias, $this->getTableAlias().'.id', $relatedTable.'.'.$relation['field']);
+            return $this->joinType($type, $relation['table'], $alias, $this->getTableAlias().'.id', $relatedTable.'.'.$relation['field']);
         }
 
         $relatedField = $relatedTable.'.id';


### PR DESCRIPTION
`$query->leftJoinRelation ($feldname)` baut einen LEFT-Join auf oder auch **nicht** (wenn be_manager_relation vom Typ 4 oder 5 ist). Der PR behebt das Problem

siehe #1082