### PR TITLE
REX_YFORM_LIST:  params[query] hinzugefügt

### DIFF
--- a/plugins/manager/lib/list.php
+++ b/plugins/manager/lib/list.php
@@ -992,7 +992,7 @@ class rex_yform_list implements rex_url_provider_interface
      */
     public function get()
     {
-        rex_extension::registerPoint(new rex_extension_point('YFORM_LIST_GET', $this, [], true));
+        rex_extension::registerPoint(new rex_extension_point('YFORM_LIST_GET', $this, ['query'=>$this->query], true));
 
         $s = "\n";
 


### PR DESCRIPTION
Ich habe versucht im EP REX_YFORM_LIST herauszufinden, welche Tabelle eigentlich die Haupttabelle ist. 
Ziel der Aktion: Abbruch der Callback-Funktion falls evtl. doch eine zweite Liste für eine andere
Tabelle generiert wird.

Leider finde ich keine Methode, die mir diese Info liefert. Es steht zwar in `$list->query`, aber die
Variable ist `private` und daher nicht zugänglich; und einen Getter gibt es wohl nicht.

Könnte man dem EP-Abruf 
https://github.com/yakamara/redaxo_yform/blob/2a6f6edb54b73fe7f6ae233c45519e1319e141b5/plugins/manager/lib/list.php#L995
die Query als 'params' mitgeben?
```php
rex_extension::registerPoint(new rex_extension_point('YFORM_LIST_GET', $this, ['query'=>$this->query], true));
```
