### PR TITLE
new value: privacy_policy

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -37,6 +37,7 @@ yform_validate_empty_notices_name = Wenn mehrere Felder ausgewählt werden muss 
 
 yform_values_checkbox_description = 			Eine <b>Checkbox</b> mit vordefinierten Werten.
 yform_values_checkbox_sql_description =			Eine <b>Checkbox</b> mit Werten, die aus einer <b>SQL-Abfrage</b> stammen.
+yform_values_privacy_policy_description =       Eine <b>Checkbox</b>, die einen <b>Zeitstempel</b> für eine Einwilligung speichert.
 yform_values_date_description =					Eine Reihe von Auswahlfeldern, in der ein <b>Datum</b> (Tag, Monat, Jahr) ausgewählt wird.
 yform_values_datestamp_description =			Ein unsichtbares Feld, in das ein <b>Zeitstempel</b> gespeichert wird, wenn der Datensatz hinzugefügt oder bearbeitet wird.
 yform_values_datestamp_notice =                 Formatierung entsprechend der PHP date() Funktion (http://php.net/manual/de/function.date.php)
@@ -91,6 +92,9 @@ yform_values_checkbox_values = Werte (0,1) (nicht angeklickt,angeklickt)
 yform_values_checkbox_values = Werte (0,1) (nicht angeklickt,angeklickt)
 yform_values_checkbox_default = Defaultstatus
 yform_values_checkbox_sql_query = Query mit "select id, name from ..""
+yform_values_privacy_policy_text = Text zur Erläuterung
+yform_values_privacy_policy_linktext = Linktitel
+yform_values_privacy_policy_article_id = REDAXO-Artikel
 yform_values_date_year_start = Startjahr
 yform_values_date_year_end = Endjahr
 yform_values_date_format = Anzeigeformat
@@ -274,5 +278,3 @@ yform_docs_yorm = Yorm
 yform_docs_email = E-Mail Templates
 yform_docs_rest = REST-API
 yform_docs_tools = Tools
-
-

--- a/lib/yform/value/privacy_policy.php
+++ b/lib/yform/value/privacy_policy.php
@@ -1,0 +1,105 @@
+<?php
+
+class rex_yform_value_privacy_policy extends rex_yform_value_abstract
+{
+    public function enterObject()
+    {
+        if (1 == $this->params['send'] && 1 != $this->getValue()) {
+            $this->setValue(0);
+        } elseif ('' != $this->getValue()) {
+            $this->setValue((1 != $this->getValue()) ? '0' : '1');
+        }
+
+        if ($this->needsOutput() && $this->isViewable()) {
+            if (!$this->isEditable()) {
+                $attributes = empty($this->getElement('attributes')) ? [] : json_decode($this->getElement('attributes'), true);
+                $attributes['disabled'] = 'disabled';
+                $this->setElement('attributes', json_encode($attributes));
+                $this->params['form_output'][$this->getId()] = $this->parse(['value.checkbox-view.tpl.php', 'value.checkbox-privacy_policy.tpl.php'], ['value' => $this->getValue()]);
+            } else {
+                $this->params['form_output'][$this->getId()] = $this->parse('value.checkbox-privacy_policy.tpl.php', ['value' => $this->getValue()]);
+            }
+        }
+
+        $this->params['value_pool']['email'][$this->getName()] = $this->getValue();
+        if ($this->saveInDb() &&  $this->getValue() == 1) {
+            $this->params['value_pool']['sql'][$this->getName()] = date("Y-m-d H:i:s");
+        }
+    }
+
+    public function getDescription()
+    {
+        return 'privacy_policy|name|label|[no_db]|text|linktext|article_id';
+    }
+
+    public function getDefinitions()
+    {
+        return [
+            'type' => 'value',
+            'name' => 'privacy_policy',
+            'values' => [
+                'name' => ['type' => 'name', 'label' => rex_i18n::msg('yform_values_defaults_name')],
+                'label' => ['type' => 'text', 'label' => rex_i18n::msg('yform_values_defaults_label')],
+                'no_db' => ['type' => 'no_db', 'label' => rex_i18n::msg('yform_values_defaults_table'), 'default' => 0],
+                'attributes' => ['type' => 'text', 'label' => rex_i18n::msg('yform_values_defaults_attributes'), 'notice' => rex_i18n::msg('yform_values_defaults_attributes_notice')],
+                'notice' => ['type' => 'text', 'label' => rex_i18n::msg('yform_values_defaults_notice')],
+                'output_values' => ['type' => 'text', 'label' => rex_i18n::msg('yform_values_status_output_values'), 'notice' => rex_i18n::msg('yform_values_status_output_values_notice')],
+                'text' => ['type' => 'text', 'label' => rex_i18n::msg('yform_values_privacy_policy_text')],
+                'linktext' => ['type' => 'text', 'label' => rex_i18n::msg('yform_values_privacy_policy_linktext')],
+                'article_id' => ['type' => 'be_link', 'label' => rex_i18n::msg('yform_values_privacy_policy_article_id')]
+            ],
+            'description' => rex_i18n::msg('yform_values_checkbox_description'),
+            'db_type' => ['datetime'],
+        ];
+    }
+
+    public static function getSearchField($params)
+    {
+        $v = 1;
+        $w = 0;
+
+        $options = [];
+        $options[$v] = rex_i18n::rawMsg('yform_values_checked');
+        $options[$w] = rex_i18n::rawMsg('yform_values_not_checked');
+        $options[''] = '---';
+
+        $params['searchForm']->setValueField('choice', [
+            'name' => $params['field']->getName(),
+            'label' => $params['field']->getLabel(),
+            'choices' => $options,
+        ]);
+    }
+
+    public static function getSearchFilter($params)
+    {
+        $value = $params['value'];
+        /** @var rex_yform_manager_query $query */
+        $query = $params['query'];
+        $field = $params['field']->getName();
+
+        return $query->where($field, $value);
+    }
+
+    public static function getListValue($params)
+    {
+        $values = $params['params']['field']['output_values'] ?? '0,1';
+        $values = explode(',', $values);
+        if (2 != count($values)) {
+            $values = [0, 1];
+        }
+
+        if ('1' === $params['subject']) {
+            return $values[1];
+        }
+        if ('0' === $params['subject']) {
+            return $values[0];
+        }
+
+        return $params['subject'];
+    }
+
+    public function getViewValue()
+    {
+        return 'hihih';
+    }
+}

--- a/ytemplates/bootstrap/value.checkbox-privacy_policy.tpl.php
+++ b/ytemplates/bootstrap/value.checkbox-privacy_policy.tpl.php
@@ -1,0 +1,40 @@
+<?php
+
+/** @var rex_yform_value_checkbox $this */
+
+$notices = [];
+if ('' != $this->getElement('notice')) {
+    $notices[] = rex_i18n::translate($this->getElement('notice'), false);
+}
+if (isset($this->params['warning_messages'][$this->getId()]) && !$this->params['hide_field_warning_messages']) {
+    $notices[] = '<span class="text-warning">' . rex_i18n::translate($this->params['warning_messages'][$this->getId()], false) . '</span>'; //    var_dump();
+}
+
+$notice = '';
+if (count($notices) > 0) {
+    $notice = '<p class="help-block">' . implode('<br />', $notices) . '</p>';
+}
+
+$class_group = trim('checkbox ' . $this->getHTMLClass() . ' ' . $this->getWarningClass());
+
+$attributes = [
+    'type' => 'checkbox',
+    'id' => $this->getFieldId(),
+    'name' => $this->getFieldName(),
+    'value' => 1,
+];
+if (1 == $value) {
+    $attributes['checked'] = 'checked';
+}
+
+$attributes = $this->getAttributeElements($attributes, ['required', 'disabled', 'autofocus']);
+
+?>
+<div class="<?= $class_group ?>" id="<?php echo $this->getHTMLId() ?>">
+    <label>
+        <input <?= implode(' ', $attributes) ?> />
+        <i class="form-helper"></i>
+        <?php echo $this->getElement('text') ?> <a target="_blank" href="<?php rex_getUrl($this->getElement('article_id')); ?>"><?php echo $this->getElement('linktext') ?></a>
+    </label>
+    <?php echo $notice; ?>
+</div>


### PR DESCRIPTION
Ein Feld zum Abfragen einer Einwilligung (Bspw. Datenschutzerklärung), welches bei Auswahl einen Zeitstempel in der DB ablegt.
 
Man könnte es alternativ auch policy nennen und in YCom für Einwilligungen benutzen (term_of_use_accepted) - Ein Zeitstempel != `0000-00-00 00:00` bedeutet, dass an diesem Datum eingewilligt wurde, sonst nicht.

Vorschau Frontend:

![image](https://user-images.githubusercontent.com/3855487/131521216-5a8891a6-8d8b-4cbe-96fa-49f0e7c89b9a.png)

Vorschau Backend:

![image](https://user-images.githubusercontent.com/3855487/131521532-84bb267a-6452-492f-b594-f81713aaec5a.png)
