### PR TITLE
in den Hilfedateien gibt es keinen Zeilenumbruch in <pre> und <code> Blöcken...

### DIFF
--- a/assets/yform-docs.css
+++ b/assets/yform-docs.css
@@ -37,7 +37,7 @@ blockquote {
 .rex-docs pre {
     background-color: #f5f5f5;
     line-height: 1.7;
-    white-space: nowrap; // pre-wrap
+    white-space: pre-wrap;
 }
 
 .rex-docs-sidebar {


### PR DESCRIPTION
.rex-docs pre, code { white-space:pre-wrap; }

jetzt:
![Zwischenablage-2](https://user-images.githubusercontent.com/1277494/137517751-df222d6b-c5a1-4398-8b51-7e048ace59a4.jpg)

nachher:
![Zwischenablage-1](https://user-images.githubusercontent.com/1277494/137517828-8fd99d19-6198-40d5-88f7-b4707416237c.jpg)


