### PR TITLE
YOrm: Native Typen, phpdocs, Optimierungen für statische Analyse

### DIFF
--- a/plugins/manager/lib/yform/manager/table.php
+++ b/plugins/manager/lib/yform/manager/table.php
@@ -62,6 +62,17 @@ class rex_yform_manager_table implements ArrayAccess
         return self::$tables[$tableName] = new self($cache[$tableName]);
     }
 
+    public static function require(string $tableName): self
+    {
+        $table = self::get($tableName);
+
+        if (!$table) {
+            throw new rex_exception('Table "'.$tableName.'" does not exist');
+        }
+
+        return $table;
+    }
+
     /**
      * @param int $tableId
      *


### PR DESCRIPTION
Die Änderungen sind sowohl hilfreich für die statische Analyse hier im Projekt, als insbesondere auch für Projekte, die YOrm nutzen.

Die nativen Typen sind streng genommen ein BC Break (bei protected/public methoden): Wenn jemand die Methode in einer Kindklasse überschreibt, muss er die Typen dort auch ergänzen.
Ich denke aber, dass man das selten macht. Üblich sind ja dataset-Kindklassen, aber halt mit zusätzlichen eigenen Methoden, selten mit überschriebenen (denke ich).
Und es wird ja sowieso die 4.0.