### PR TITLE
rex_yform_list: setColumnPosition/getColumnPosition

### DIFF
--- a/plugins/manager/lib/list.php
+++ b/plugins/manager/lib/list.php
@@ -604,6 +604,52 @@ class rex_yform_list implements rex_url_provider_interface
         return isset($this->columnParams[$columnName]) && is_array($this->columnParams[$columnName]) && count($this->columnParams[$columnName]) > 0;
     }
 
+    /**
+     * Verschiebt eine Spalte an eine andere Position in der Spaltenliste.
+     *
+     * @param string        $columnName   Name der Spalte
+     * @param int|string    $columnIndex  Einfügen vor der angegebenen Spalte
+     *                                    (Spalten-Index analog zu addColumn oder Spaltenname)
+     *
+     * @return int          Spaltennummer der neuen Position
+     */
+    public function setColumnPosition(string $columnName, $columnIndex): int
+    {
+        $currentIndex = $this->getColumnPosition($columnName);
+
+        if (is_string($columnIndex)) {
+            $columnIndex = $this->getColumnPosition($columnIndex);
+        }
+
+        // Bei negativem columnIndex das Element am Ende anfügen
+        if (0 > $columnIndex) {
+            $columnIndex = count($this->columnNames);
+        }
+
+        unset($this->columnNames[$currentIndex]);
+        array_splice($this->columnNames, $columnIndex, 0, [$columnName]);
+
+        return $columnIndex;
+    }
+
+    /**
+     * Gibt die Position einer Spalte zurück.
+     *
+     * @param string     $columnName   Name der Spalte
+     *
+     * @throws InvalidArgumentException   $columnName kommt in $this->columnNames nicht vor
+     *
+     * @return int       Index der Spalte
+     */
+    public function getColumnPosition(string $columnName): int
+    {
+        $position = array_search($columnName, $this->columnNames);
+        if (false === $position) {
+            throw new InvalidArgumentException('Unkown column name "'.$columnName.'".');
+        }
+        return $position;
+    }
+
     // ---------------------- TableColumnGroup setters/getters/etc
 
     /**


### PR DESCRIPTION
Wie schon in #1080 beschrieben schlage ich zwei weitere Methoden für die rex_list bzw. rex_yform_list vor. In rex_list sind die Änderungen akzeptiert und gemerged. Dieser PR übernimmt den finalen Code aus rex_list 1:1 für rex_yform_list.
