### PR TITLE
Notice vermeiden

### DIFF
--- a/plugins/manager/lib/yform/manager/field.php
+++ b/plugins/manager/lib/yform/manager/field.php
@@ -118,7 +118,7 @@ class rex_yform_manager_field implements ArrayAccess
             if ('' != $this->values['table']) {
                 $tables[] = $this->values['table'];
             }
-            if ('' != $this->values['relation_table']) {
+            if (isset($this->values['relation_table']) && '' != $this->values['relation_table']) {
                 $tables[] = $this->values['relation_table'];
             }
         }


### PR DESCRIPTION
fixed #1121, fixed #1098

Die Notice erscheint, sobald im `be_manager_relation` Value keine Relationstabelle gesetzt wurde.

Beachten müsste man auch, ob `$this->values['relation_table']` immer gesetzt jedoch leer sein darf oder wie aktuell der Key nicht in values vorhanden ist.