### PR TITLE
Umwandlung eines leeren Datums gefixed

### DIFF
--- a/lib/yform/value/date.php
+++ b/lib/yform/value/date.php
@@ -31,14 +31,14 @@ class rex_yform_value_date extends rex_yform_value_abstract
             $value = date('Y-m-d');
         }
         if (is_array($value)) {
-            $year = (int) $value['year'] ?? 0;
-            $month = (int) $value['month'] ?? 0;
-            $day = (int) $value['day'] ?? 0;
+            $year = (int) ($value['year'] ?? 0);
+            $month = (int) ($value['month'] ?? 0);
+            $day = (int) ($value['day'] ?? 0);
         } else {
             $value = explode("-", (string) $value);
-            $year = (int) $value[0] ?? 0;
-            $month = (int) $value[1] ?? 0;
-            $day = (int) $value[2] ?? 0;
+            $year = (int) ($value[0] ?? 0);
+            $month = (int) ($value[1] ?? 0);
+            $day = (int) ($value[2] ?? 0);
         }
         $value = sprintf("%04d-%02d-%02d", $year, $month, $day);
         $this->setValue($value);
@@ -48,14 +48,14 @@ class rex_yform_value_date extends rex_yform_value_abstract
     {
         $value = $this->getValue();
         if (is_array($value)) {
-            $year = (int) $value['year'] ?? 0;
-            $month = (int) $value['month'] ?? 0;
-            $day = (int) $value['day'] ?? 0;
+            $year = (int) ($value['year'] ?? 0);
+            $month = (int) ($value['month'] ?? 0);
+            $day = (int) ($value['day'] ?? 0);
         } else {
             $value = explode("-", (string) $value);
-            $year = (int) $value[0] ?? 0;
-            $month = (int) $value[1] ?? 0;
-            $day = (int) $value[2] ?? 0;
+            $year = (int) ($value[0] ?? 0);
+            $month = (int) ($value[1] ?? 0);
+            $day = (int) ($value[2] ?? 0);
         }
         $value = sprintf("%04d-%02d-%02d", $year, $month, $day);
         $this->setValue($value);


### PR DESCRIPTION
`(int) $value[..] ?? 0` fürt zu einer Umwandlungswarnung wenn `$value[..]` null ist. Behoben mit `(int) ($value[..] ?? 0)`

Closes #1159 