### PR TITLE
remove Error-occured

### DIFF
--- a/docs/07_formbuilder.md
+++ b/docs/07_formbuilder.md
@@ -446,7 +446,6 @@ Folgende Objparams find verfügbar:
 - `data`: Boolean.
 - `debug`: Boolean. Aktiviert den Debugmodus
 - `error_class`: CSS Klasse des Fehlerfelds
-- `Error-occured`: Freitext oberhalb auftgetretener Fehlermeldungen.
 - `Error-Code-EntryNotFound`: Standard: 'ErrorCode - EntryNotFound'
 - `Error-Code-InsertQueryError`: Standard 'ErrorCode - InsertQueryError'
 - `fieldsets_opened`:

--- a/lib/yform.php
+++ b/lib/yform.php
@@ -55,7 +55,6 @@ class rex_yform
         $this->objparams['postactions_executed'] = false;
         $this->objparams['preactions_executed'] = false;
 
-        $this->objparams['Error-occured'] = '';
         $this->objparams['Error-Code-EntryNotFound'] = 'ErrorCode - EntryNotFound';
         $this->objparams['Error-Code-QueryError'] = 'ErrorCode - QueryError';
 

--- a/ytemplates/bootstrap/errors.tpl.php
+++ b/ytemplates/bootstrap/errors.tpl.php
@@ -1,17 +1,10 @@
 <div class="alert alert-danger">
 
-<?php
-if ($this->objparams['warning_messages'] || $this->objparams['unique_error']):
-    if ($this->objparams['Error-occured']): ?>
-        <dl class="dl-horizontal">
-            <dt><?php echo $this->objparams['Error-occured'] ?></dt>
-            <dd>
-                <ul>
-    <?php else: ?>
-                <ul>
-    <?php endif; ?>
-                    <?php
+<?php if ($this->objparams['warning_messages'] || $this->objparams['unique_error']): ?>
 
+    <ul>
+
+    <?php
     $warning_messages = [];
     foreach ($this->objparams['warning_messages'] as $k => $v) {
         $message = rex_i18n::translate("$v", null);
@@ -27,13 +20,10 @@ if ($this->objparams['warning_messages'] || $this->objparams['unique_error']):
     if ('' != $this->objparams['unique_error']) {
         echo '<li>'.rex_i18n::translate(preg_replace('~\\*|:|\\(.*\\)~Usim', '', $this->objparams['unique_error'])).'</li>';
     }
-
     ?>
-                </ul>
-    <?php if ($this->objparams['Error-occured']): ?>
-            </dd>
-        </dl>
-    <?php endif;
-endif;
-?>
+
+    </ul>
+
+<?php endif; ?>
+
 </div>


### PR DESCRIPTION
Error-occured ist in der formbilder.md als "Freitext oberhalt aufgetretener Fehlermeldung definiert",
wird in der yform.php als '' gesetzt
und in der errors.tmpl.php als <dl> ausgegeben.

Es gibt aber keine Stelle an der man es setzen kann.
Falls es ein noch nicht integriertes Feature ist, kann es vermutlich weg?
Ich habs mal rausgeworfen falls sich das bestätigt.