### PR TITLE
fehlenden objparam hinzugefügt

### DIFF
--- a/lib/yform.php
+++ b/lib/yform.php
@@ -58,6 +58,7 @@ class rex_yform
         $this->objparams['Error-occured'] = '';
         $this->objparams['Error-Code-EntryNotFound'] = 'ErrorCode - EntryNotFound';
         $this->objparams['Error-Code-QueryError'] = 'ErrorCode - QueryError';
+        $this->objparams['Error-Code-InsertQueryError'] = 'ErrorCode - InsertQueryError';
 
         $this->objparams['csrf_protection'] = true;
         $this->objparams['csrf_protection_error_message'] = '{{ csrf.error }}';


### PR DESCRIPTION
An mehreren Stellen (z.B. https://github.com/yakamara/redaxo_yform/blob/master/lib/yform/action/db.php#L27) wird  `$this->params['Error-Code-InsertQueryError']` verwendet.

Dieser param fehlt aber in yform.php
Nur "Error-Code-QueryError" existiert als yform objparam:
https://github.com/yakamara/redaxo_yform/blob/master/lib/yform.php#L60

![Zwischenablage-1](https://user-images.githubusercontent.com/1277494/146644198-3a212ed6-99d3-4ac7-9fdf-ac1bb6182152.jpg)

