### PR TITLE
update package version

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: yform
-version: '4.0.0-beta4'
+version: '4.0.0-beta7'
 author: 'Jan Kristinus, Gregor Harlan'
 supportpage: 'https://github.com/yakamara/redaxo_yform/issues'
 compile: 0


### PR DESCRIPTION
die GitHub-Version ist aktueller als die im Installer, hier sind die Versionsnummern durcheinander gekommen. Mit der aktuellen GitHub-Version wird mir ein Update im Installer angeboten.