### PR TITLE
Oops bei Formularen mit inline Relation verhindern

### DIFF
--- a/lib/yform/action/redirect.php
+++ b/lib/yform/action/redirect.php
@@ -37,6 +37,9 @@ class rex_yform_action_redirect extends rex_yform_action_abstract
         }
 
         foreach ($this->params['value_pool']['email'] as $search => $replace) {
+            if (is_array($replace)) {
+                continue;
+            }
             $url = str_replace('###' . $search . '###', urlencode($replace), $url);
         }
 


### PR DESCRIPTION
Wenn in einem Formular eine Inline Relation verwendet wird, gibt es den entsprechenden Value als Array im value_pool.
Das knallt bei urlencode. Die drei zusätzlichen Zeilen verhindern dies.