### PR TITLE
Update auf 4.0: Backticks um 'default' in SQL-Abfrage zur Feldänderung

### DIFF
--- a/plugins/manager/install.php
+++ b/plugins/manager/install.php
@@ -147,7 +147,7 @@ if ($this->isInstalled()) {
                 case 'float':
                     // change to number
                     rex_sql::factory()->setQuery('update `' . rex::getTable('yform_field') . '` set
-                        type_name = "number", db_type = "", default = ""
+                        type_name = "number", db_type = "", `default = ""
                         where id = :id', ['id' => $field['id']]);
                     break;
 

--- a/plugins/manager/install.php
+++ b/plugins/manager/install.php
@@ -147,7 +147,7 @@ if ($this->isInstalled()) {
                 case 'float':
                     // change to number
                     rex_sql::factory()->setQuery('update `' . rex::getTable('yform_field') . '` set
-                        type_name = "number", db_type = "", `default = ""
+                        type_name = "number", db_type = "", `default` = ""
                         where id = :id', ['id' => $field['id']]);
                     break;
 


### PR DESCRIPTION
Beim Update von 4.0.0-beta6 auf 4.0.0 (final) kommt ein SQL-Fehler.

<img width="1245" alt="grafik" src="https://user-images.githubusercontent.com/10065904/147695010-147b944c-eb24-4282-8859-9429af8cd79f.png">

Wenn ich manuell in der Zeile mit ID=25 den `type_name` von `float` auf `number` setze, bricht er bei der nächsten Zeile 26 ab. Selbes Problem. Test der SQL-Abfrage im Adminer zeigt: `default` muß in Backticks weil in SQL ein reserviertes Wort.
