### PR TITLE
ReturnTypeWillChange-Attribut nutzen

### DIFF
--- a/plugins/manager/lib/yform/manager/field.php
+++ b/plugins/manager/lib/yform/manager/field.php
@@ -200,6 +200,7 @@ class rex_yform_manager_field implements ArrayAccess
     }
 
     // ------------------------------------------- Array Access
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (null === $offset) {
@@ -209,16 +210,19 @@ class rex_yform_manager_field implements ArrayAccess
         }
     }
 
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->values[$offset]);
     }
 
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->values[$offset]);
     }
 
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->values[$offset];

--- a/plugins/manager/lib/yform/manager/table.php
+++ b/plugins/manager/lib/yform/manager/table.php
@@ -438,6 +438,7 @@ class rex_yform_manager_table implements ArrayAccess
     }
 
     // ------------------------------------------- Array Access
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (null === $offset) {
@@ -447,16 +448,19 @@ class rex_yform_manager_table implements ArrayAccess
         }
     }
 
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->values[$offset]);
     }
 
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->values[$offset]);
     }
 
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->values[$offset];


### PR DESCRIPTION
Mit PHP 8.1 kommen diese Deprecated-Meldungen:

> During inheritance of ArrayAccess: Uncaught ErrorException: Return type of rex_yform_manager_table::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

Aktuell werden die Meldungen im Rex-Autoloader stummgeschaltet, das möchte ich aber eventuell ändern.

Alternativ zu den Attributen könnte auch der richtige Return-Type hinzugefügt werden. Ist aber problematisch in einem Minor-Release.

Die Attribute funktionieren auch in PHP 7, dort sind es ja einfach nur Kommentare.