### PR TITLE
Warnung bei Massenbearbeitung

### DIFF
--- a/plugins/manager/lang/de_de.lang
+++ b/plugins/manager/lang/de_de.lang
@@ -163,6 +163,8 @@ yform_dataset_delete = Datenergebnis löschen
 yform_dataset_deleted = Datenergebnis wurde geleert
 yform_dataset_delete_confirm = Wirklich das Datenergebnis leeren?
 
+yform_dataset_edit_confirm = Sollen wirklich alle Datensätze bearbeitet werden?
+
 yform_data = Datensatz
 yform_datas = Datensätze
 yform_manager_search = Suche

--- a/plugins/manager/lang/de_de.lang
+++ b/plugins/manager/lang/de_de.lang
@@ -163,7 +163,7 @@ yform_dataset_delete = Datenergebnis löschen
 yform_dataset_deleted = Datenergebnis wurde geleert
 yform_dataset_delete_confirm = Wirklich das Datenergebnis leeren?
 
-yform_dataset_edit_confirm = Sollen wirklich alle Datensätze bearbeitet werden?
+yform_dataset_edit_confirm = Sollen wirklich alle gewählten Datensätze bearbeitet werden?
 
 yform_data = Datensatz
 yform_datas = Datensätze

--- a/plugins/manager/lib/yform/manager.php
+++ b/plugins/manager/lib/yform/manager.php
@@ -683,7 +683,7 @@ class rex_yform_manager
                 $item['label'] = rex_i18n::msg('yform_edit');
                 $item['url'] = 'index.php?' . http_build_query(array_merge(['func' => 'collection_edit'], $rex_link_vars));
                 $item['attributes']['class'][] = 'btn-default';
-                $item['attributes']['data-confirm'][] = rex_i18n::msg('yform_edit_all_datasets');
+                $item['attributes']['data-confirm'][] = rex_i18n::msg('yform_dataset_edit_confirm ');
                 $dataset_links[] = $item;
             }
 

--- a/plugins/manager/lib/yform/manager.php
+++ b/plugins/manager/lib/yform/manager.php
@@ -683,6 +683,7 @@ class rex_yform_manager
                 $item['label'] = rex_i18n::msg('yform_edit');
                 $item['url'] = 'index.php?' . http_build_query(array_merge(['func' => 'collection_edit'], $rex_link_vars));
                 $item['attributes']['class'][] = 'btn-default';
+                $item['attributes']['data-confirm'][] = rex_i18n::msg('yform_edit_all_datasets');
                 $dataset_links[] = $item;
             }
 


### PR DESCRIPTION
Nutzer sollten noch mal darauf hingewiesen werden, dass hier alle gefunden Datensätze bearbeitet werden. 
Es ist schon vorgekommen, dass versehentlich durch Nutzer alle Datensätze überschrieben wurden.
