### PR TITLE
datetime-local-Format unterstützen

### DIFF
--- a/lib/yform/value/datetime.php
+++ b/lib/yform/value/datetime.php
@@ -10,7 +10,7 @@
 class rex_yform_value_datetime extends rex_yform_value_abstract
 {
     public const VALUE_DATETIME_DEFAULT_FORMAT = 'Y-m-d H:i:s';
-    public const VALUE_DATETIME_FORMATS = ['d.m.Y H:i:s' => 'd.m.Y H:i:s', 'Y-m-d H:i:s' => 'Y-m-d H:i:s', 'd-m-Y H:i:s' => 'd-m-Y H:i:s', 'm-d-Y H:i:s' => 'm-d-Y H:i:s', 'm-Y H:i:s' => 'm-Y H:i:s', 'Y-m H:i:s' => 'Y-m H:i:s', 'd-m H:i:s' => 'd-m H:i:s', 'm-d H:i:s' => 'm-d H:i:s', 'Y' => 'Y', 'Y-m' => 'Y-m'];
+    public const VALUE_DATETIME_FORMATS = ['d.m.Y H:i:s' => 'd.m.Y H:i:s', 'Y-m-d H:i:s' => 'Y-m-d H:i:s', 'Y-m-dTH:i' => 'Y-m-dTH:i (HTML5 datetime-local)', 'd-m-Y H:i:s' => 'd-m-Y H:i:s', 'm-d-Y H:i:s' => 'm-d-Y H:i:s', 'm-Y H:i:s' => 'm-Y H:i:s', 'Y-m H:i:s' => 'Y-m H:i:s', 'd-m H:i:s' => 'd-m H:i:s', 'm-d H:i:s' => 'm-d H:i:s', 'Y' => 'Y', 'Y-m' => 'Y-m'];
 
     public function preValidateAction(): void
     {


### PR DESCRIPTION
Im Firefox fällt das nicht auf, der versteht auch `2022-01-14 17:07:59`, jedoch ist die offizielle Anforderung `2022-01-14T17:07` (mit T, ohne Sekunden)

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local