### PR TITLE
showtext Erfolgsmeldung über Templates anpassbar machen

### DIFF
--- a/lib/yform/action/abstract.php
+++ b/lib/yform/action/abstract.php
@@ -15,4 +15,12 @@ abstract class rex_yform_action_abstract extends rex_yform_base_abstract
     {
         return 1;
     }
+    
+    public function parse($template, $params = [])
+    {
+        extract($params);
+        ob_start();
+        include $this->params['this']->getTemplatePath($template);
+        return ob_get_clean();
+    }
 }

--- a/lib/yform/action/showtext.php
+++ b/lib/yform/action/showtext.php
@@ -25,7 +25,7 @@ class rex_yform_action_showtext extends rex_yform_action_abstract
             $text = str_replace('###' . $search . '###', $replace, $text);
         }
 
-        $this->params['output'] .= $text;
+        $this->params['output'] .= $this->parse('action.showtext.tpl.php', ['text' => $text]);
     }
 
     public function getDescription(): string

--- a/ytemplates/bootstrap/action.showtext.tpl.php
+++ b/ytemplates/bootstrap/action.showtext.tpl.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * @var rex_yform $this
+ * @psalm-scope-this rex_yform
+ */
+
+?>
+<?= $this->text;


### PR DESCRIPTION
Mit diesem PR beabsichtige ich, dass showtext als Erfolgsmeldung mehr Möglichkeiten bekommt, z.B. von eigenen Templates zur Ausgabe überschrieben werden zu können.

Vielleicht wäre es auch sinnvoll, mehr Kontext mitzugeben (bspw. die fertige ID des Datensatzes oder Infos zum Formular selbst oder dem Datensatz), fürs erste würde das jedoch schon genügen.