### PR TITLE
Textareas mit mehr als 400 Zeichen

### DIFF
--- a/ytemplates/bootstrap/value.view.tpl.php
+++ b/ytemplates/bootstrap/value.view.tpl.php
@@ -29,9 +29,13 @@ if ('' != $download_link) {
     $title = $value;
     $maxsize = 400;
     if ($length > $maxsize) {
-        $value = mb_substr($value, 0, (int) ($maxsize / 2)).' ... '.mb_substr($value, (int) (-($maxsize / 2)));
+        $value = rex_escape($value);
+        $fullValue = '<span class="collapse" id="'.$this->getFieldId().'">... ' . substr($value,strpos($value, ' ', 50), -1) . '</span>';
+        $value = '<div>'.substr($value,0,strpos($value, ' ', 50)) . ' ...</div>' . $fullValue . '
+        <div class="btn-group btn-toggle">
+            <span class="btn btn-default btn-xs" data-toggle="collapse" data-target="#'.$this->getFieldId().'">Ein-/Ausblenden</span>
+        </div>';
     }
-    $value = rex_escape($value);
 }
 
 $class_group = [];


### PR DESCRIPTION
Aktuell werden Textareas mit mehr als 400 Zeichen gekürzt angezeigt. In meinem UseCase ist das doof und ich verstehe ehrlich gesagt auch nicht, warum man Leserecht auf einen Inhalt hat und dann den Inhalt nicht ansehen kann. Zumal das nirgends erwähnt wird. Ich hab hier aktuell alles durch gestetet und es lief. Im Livebetrieb hat der Kunde mich dann aufgeregt angerufen ...

Anbei vielleicht eine Lösung des Problems? Ich habs noch nicht ganz ausgearbeitet weil ich nicht weiß ob du überhaupt interesse hast.