### PR TITLE
Tabelle responsive machen

### DIFF
--- a/plugins/manager/lib/list.php
+++ b/plugins/manager/lib/list.php
@@ -1061,6 +1061,7 @@ class rex_yform_list implements rex_url_provider_interface
         // Form vars
         $this->addFormAttribute('action', $this->getUrl([], false));
         $this->addFormAttribute('method', 'post');
+        $this->addFormAttribute('class', 'table-responsive');
 
         // Table vars
         $caption = $this->getCaption();


### PR DESCRIPTION
fügt dem Elternelement der Tabelle eine Bootstrap-Klasse hinzu, die die Tabelle scrollbar macht, statt überzulaufen.

## Vorher
![image](https://user-images.githubusercontent.com/3855487/158017050-1aa660a7-efa8-467b-84de-cfece5151f36.png)

## Nachher

![image](https://user-images.githubusercontent.com/3855487/158017037-1a056af9-f33f-4812-a2cf-748b1535e2eb.png)
