### PR TITLE
Für PHP8.1: NULL-Value in str_replace vermeiden

### DIFF
--- a/plugins/manager/lib/list.php
+++ b/plugins/manager/lib/list.php
@@ -945,7 +945,7 @@ class rex_yform_list implements rex_url_provider_interface
      */
     public function replaceVariable($string, $varname)
     {
-        return str_replace(['###' . $varname . '###','___'.$varname.'___'], rex_escape($this->getValue($varname)), $string);
+        return str_replace(['###' . $varname . '###','___'.$varname.'___'], rex_escape((string)$this->getValue($varname)), $string);
     }
 
     /**


### PR DESCRIPTION
mit PHP 8.1 sind NULL-Parameter on str_replace nicht mehr zulässig (Warnung wg. deprecated). Das passiert z.B. wenn ein Feld vom Typ be_manager_relation zwar als YForm-Tabellenfeld (z.B. xyz) existiert, aber keine Entsprechung in einem real existierenden Feld in der Datenbank hat. Dann ist das Feld xyz als Tabellenfeld in der Liste vorhanden, aber $this->getValue('xyz') liefert null. Typecast auf "string" führt wieder zum gewohnten Ergebnis.