### PR TITLE
In der Query-Klasse findId/findIds mit Table-Alias ausführen

### DIFF
--- a/plugins/manager/lib/yform/manager/query.php
+++ b/plugins/manager/lib/yform/manager/query.php
@@ -581,7 +581,7 @@ class rex_yform_manager_query implements IteratorAggregate, Countable
      */
     public function findIds(array $ids): rex_yform_manager_collection
     {
-        return $this->where('id', $ids)->find();
+        return $this->where($this->getTableAlias().'.id', $ids)->find();
     }
 
     /**
@@ -600,7 +600,7 @@ class rex_yform_manager_query implements IteratorAggregate, Countable
      */
     public function findId(int $id): ?rex_yform_manager_dataset
     {
-        return $this->where('id', $id)->resetOrderBy()->findOne();
+        return $this->where($this->getTableAlias().'.id', $id)->resetOrderBy()->findOne();
     }
 
     /**


### PR DESCRIPTION
Folgender Code führt zu einer Exception:

```php
$result = \rex_yform_manager_query::get('rex_geolocation_mapset')
    ->alias('a')
    ->joinRelation ('layer','b')
    ->select('a.*')
    ->select('b.*')
    ->findId(1);
```

```
Error while executing statement "SELECT `rex_geolocation_mapset`.* FROM `rex_geolocation_mapset`
INNER JOIN `rex_geolocation_layer` ON FIND_IN_SET(`rex_geolocation_layer`.`id`,
`rex_geolocation_mapset`.`layer`) WHERE `id` = :p1 LIMIT 1" using params {"p1":1}!
SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'id' in where clause is ambiguous
```

Was funktioniert ist ein explizietes Where mit Tablealias im Feldnamen

```php
$result = \rex_yform_manager_query::get('rex_geolocation_mapset')
    ->alias('a')
    ->joinRelation ('layer','b')
    ->select('a.*')
    ->select('b.*')
    ->where('a.id', '1')
    ->find();
```

Ursache des Fehlers: in den Methoden `findId()` und `findIds()` wird ein `"where('id',..)"` generiert,
während an anderen Stellen in der Query-Klasse sicherheitshalber der Alias hinzugefügt wird
(siehe PR #1083, #1087 und Issue #1070).

Vorschlag in diesem PR: auch in den beiden genannten Methoden `'id' um den Tablename/Tablealias ergänzen
