### PR TITLE
Type email und url für DE-Umlaute erweitert

### DIFF
--- a/lib/yform/validate/type.php
+++ b/lib/yform/validate/type.php
@@ -45,12 +45,12 @@ class rex_yform_validate_type extends rex_yform_validate_abstract
             case 'string':
                 break;
             case 'email':
-                if (!preg_match("/^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/", $Object->getValue())) {
+                if (!preg_match("/^[a-zä-üA-ZÄ-Ü0-9ß.!#$%&'*+\/=?^_`{|}~-]+@[a-zä-üA-ZÄ-Ü0-9ß](?:[a-zä-üA-ZÄ-Ü0-9ß-]{0,61}[a-zä-üA-ZÄ-Ü0-9ß])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/", $Object->getValue())) {
                     $w = true;
                 }
                 break;
             case 'url':
-                $xsRegEx_url = '/^(?:http[s]?:\/\/)[a-zA-Z0-9][a-zA-Z0-9._-]*\.(?:[a-zA-Z0-9][a-zA-Z0-9._-]*\.)*[a-zA-Z]{2,20}(?:\/[^\\/\:\*\?\"<>\|]*)*(?:\/[a-zA-Z0-9_%,\.\=\?\-#&]*)*$' . '/';
+                $xsRegEx_url = '/^(?:http[s]?:\/\/)[a-zä-üA-ZÄ-Ü0-9ß][a-zä-üA-ZÄ-Ü0-9ß._-]*\.(?:[a-zä-üA-ZÄ-Ü0-9ß][a-zä-üA-ZÄ-Ü0-9ß._-]*\.)*[a-zA-Z]{2,20}(?:\/[^\\/\:\*\?\"<>\|]*)*(?:\/[a-zA-Z0-9_%,\.\=\?\-#&]*)*$' . '/';
                 if (0 == preg_match($xsRegEx_url, $Object->getValue())) {
                     $w = true;
                 }


### PR DESCRIPTION
E-Mail Adressen wie hänßchen@aus-dem-häußchen.de werden von Validate type email wegen der Umlaute abgelehnt. Tests mit filter_var(..., FILTER_VALIDATE_EMAIL) haben das gleiche Ergebnis ergeben. Daher hier ein Vorschlag, wie die Umlaute als korrekt validiert werden.
Ich bin kein Regexprofi, daher gerne nochmal anschauen :-)