### PR TITLE
ignore `.tools/vendor` for release

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -33,4 +33,4 @@ system_plugins:
     - email
 
 installer_ignore:
-    - .tools/vendor
+    - .tools

--- a/package.yml
+++ b/package.yml
@@ -31,3 +31,6 @@ requires:
 system_plugins:
     - manager
     - email
+
+installer_ignore:
+    - .tools/vendor


### PR DESCRIPTION
Im aktuellen Release 4.0.2 scheint der Ordner `.tools/vendor` mit gezipped worden zu sein.

```bash
marcel@matzel-linux:~/$ du -hs addon_yform_4.0.2/yform/
39M	addon_yform_4.0.2/yform/

marcel@matzel-linux:~/$ du -hs addon_yform_4.0.2/yform/.tools/vendor/
36M	addon_yform_4.0.2/yform/.tools/vendor/
```

fixes https://github.com/yakamara/redaxo_yform/issues/1254