### PR TITLE
Modul :: form action aktuellen Artikel ermitteln

### DIFF
--- a/module/module_output.inc
+++ b/module/module_output.inc
@@ -17,7 +17,8 @@ if ('REX_VALUE[7]' == 1) {
 }
 $form_data = 'REX_VALUE[id=3 output=html]';
 $form_data = trim(rex_yform::unhtmlentities($form_data));
-$yform->setObjectparams('form_action', rex_getUrl(REX_ARTICLE_ID, REX_CLANG_ID));
+$yform->setObjectparams('form_action', rex_getUrl(rex_article::getCurrentId(), REX_CLANG_ID)); 
+
 $yform->setFormData($form_data);
 
 // action - showtext


### PR DESCRIPTION
Die aktuelle Schreibweise funktioniert nicht, sollte das Formular mal eingebunden werden. Das Ziel ist dann immer der eingebundene Artikel.