### PR TITLE
RexStan / rex_yform_choice_view: fehlenden Datentyp "array" ergänzt

### DIFF
--- a/lib/yform/value/Choice/rex_yform_choice_view.php
+++ b/lib/yform/value/Choice/rex_yform_choice_view.php
@@ -13,10 +13,10 @@ class rex_yform_choice_view
     /**
      * Creates a new choice view.
      *
-     * @param string          $value              The view representation of the choice
-     * @param string          $label              The label displayed to humans
-     * @param callable|string $attributes         Additional attributes for the HTML tag
-     * @param array           $requiredAttributes Required attributes for the HTML tag
+     * @param string                $value              The view representation of the choice
+     * @param string                $label              The label displayed to humans
+     * @param callable|string|array $attributes         Additional attributes for the HTML tag
+     * @param array                 $requiredAttributes Required attributes for the HTML tag
      */
     public function __construct($value, $label, $attributes = null, array $requiredAttributes = [])
     {


### PR DESCRIPTION
Im Construktor gibt es den dritten Parameter `$attributes`, der laut Code `callable`, `string` oder `array` sein kann.  
```php
        if (is_callable($attributes)) {
            $this->attributes = call_user_func($attributes, $this->getValue(), $this->getLabel());
        } elseif (!is_array($attributes)) {
            $this->attributes = json_decode(trim($attributes), true);
        }
```
Im PHPDoc ist er nur als `@param callable|string $attributes` definiert. Das führt bei der RexStan-Evaluierung in darauf aufsetzendem Code zum Fehler "**Parameter #&#8203;3 $attributes of class rex_yform_choice_view constructor expects (callable(): mixed)|string|null, non-empty-array given.**" , wenn ein Array übergeben wird.

Hier mal als Lösungsvorschlag zusätzlich `array` als dritte Variante.
```php
    /**
     * Creates a new choice view.
     *
     * @param string                $value              The view representation of the choice
     * @param string                $label              The label displayed to humans
     * @param callable|string|array $attributes         Additional attributes for the HTML tag
     * @param array                 $requiredAttributes Required attributes for the HTML tag
     */
```
Das hat zumindest bei meinem Test die Meldung beseitigt