### PR TITLE
dataset save - add history enable/disable feature

### DIFF
--- a/plugins/manager/boot.php
+++ b/plugins/manager/boot.php
@@ -100,7 +100,7 @@ rex_extension::register('YFORM_SAVED', static function (rex_extension_point $ep)
     }
     $dataset->invalidateData();
 
-    if ($table->hasHistory()) {
+    if ($table->hasHistory() && $dataset->isHistoryEnabled()) {
         $action = 'insert' === $ep->getParam('action') ? rex_yform_manager_dataset::ACTION_CREATE : rex_yform_manager_dataset::ACTION_UPDATE;
         $dataset->makeSnapshot($action);
     }

--- a/plugins/manager/lib/yform/manager/dataset.php
+++ b/plugins/manager/lib/yform/manager/dataset.php
@@ -41,6 +41,9 @@ class rex_yform_manager_dataset
     /** @var string[] */
     private $messages = [];
 
+    /** @var bool */
+    private $historyEnabled = true;
+
     final private function __construct(string $table, ?int $id = null)
     {
         $this->table = $table;
@@ -634,6 +637,16 @@ class rex_yform_manager_dataset
         }
 
         return $this->save();
+    }
+
+    public function isHistoryEnabled(): bool
+    {
+        return $this->historyEnabled;
+    }
+
+    public function setHistoryEnabled(bool $historyEnabled): void
+    {
+        $this->historyEnabled = $historyEnabled;
     }
 
     public function __isset(string $key): bool


### PR DESCRIPTION
Mit dieser Funktion könnte man beim Speichern von Datensätzen die history abschalten.
Beispielsweise für cronjobs, die sehr häufig Daten überschreiben und dadurch sehr viele history Daten produzieren.

https://github.com/yakamara/redaxo_yform/issues/1307