### PR TITLE
validate "type" Feld - Reihenfolge der Parameter "type" and "name" sind vertauscht

### DIFF
--- a/lib/yform/validate/type.php
+++ b/lib/yform/validate/type.php
@@ -160,8 +160,8 @@ class rex_yform_validate_type extends rex_yform_validate_abstract
             'type' => 'validate',
             'name' => 'type',
             'values' => [
-                'name' => ['type' => 'select_name', 'label' => rex_i18n::msg('yform_validate_type_name')],
                 'type' => ['type' => 'choice',    'label' => rex_i18n::msg('yform_validate_type_type'), 'choices' => 'int,float,numeric,string,email,url,time,date,datetime,hex,iban,json'],
+                'name' => ['type' => 'select_name', 'label' => rex_i18n::msg('yform_validate_type_name')],
                 'message' => ['type' => 'text',    'label' => rex_i18n::msg('yform_validate_type_message')],
                 'not_required' => ['type' => 'boolean',    'label' => rex_i18n::msg('yform_validate_type_not_required'), 'default' => 0],
             ],


### PR DESCRIPTION
Das führte bei mir dazu, dass 
`validate|type|email|emailfeld|E-Mail` nicht klappt.

![Zwischenablage-lus1](https://user-images.githubusercontent.com/1277494/203316591-59585b3f-3444-4e42-8b39-1f08b94de44e.jpg)

![Zwischenablage-lus2](https://user-images.githubusercontent.com/1277494/203317810-323ab737-3989-4d70-a8b1-dae326c7a42c.jpg)


Es wird dann eben das Feld "email" gesucht...