### PR TITLE
i18n-Namen korrigiert

### DIFF
--- a/plugins/manager/ytemplates/bootstrap/value.be_manager_relation.tpl.php
+++ b/plugins/manager/ytemplates/bootstrap/value.be_manager_relation.tpl.php
@@ -101,7 +101,7 @@ $e = [];
         $e['moveButtons'] = '
                 <a href="javascript:void(0);" class="btn btn-popup" onclick="moveYFormDatasetList(' . $id . ',\'top\');return false;" title="' . rex_i18n::msg('yform_relation_move_first_data') . '"><i class="rex-icon rex-icon-top"></i></a>
                 <a href="javascript:void(0);" class="btn btn-popup" onclick="moveYFormDatasetList(' . $id . ',\'up\');return false;" title="' . rex_i18n::msg('yform_relation_move_up_data') . '>"><i class="rex-icon rex-icon-up"></i></a>
-                <a href="javascript:void(0);" class="btn btn-popup" onclick="moveYFormDatasetList(' . $id . ',\'down\');return false;" title="' . rex_i18n::msg('yform_relation_down_first_data') . '"><i class="rex-icon rex-icon-down"></i></a>
+                <a href="javascript:void(0);" class="btn btn-popup" onclick="moveYFormDatasetList(' . $id . ',\'down\');return false;" title="' . rex_i18n::msg('yform_relation_move_down_data') . '"><i class="rex-icon rex-icon-down"></i></a>
                 <a href="javascript:void(0);" class="btn btn-popup" onclick="moveYFormDatasetList(' . $id . ',\'bottom\');return false;" title="' . rex_i18n::msg('yform_relation_move_last_data') . '"><i class="rex-icon rex-icon-bottom"></i></a>';
         $e['functionButtons'] = '
                 <a href="javascript:void(0);" class="btn btn-popup" onclick="openYFormDatasetList(' . $id . ', \'' . $this->getRelationSourceTableName() . '.' . $this->getName() . '\', \'' . $link . '\',\'1\');return false;" title="' . rex_i18n::msg('yform_relation_choose_entry') . '"><i class="rex-icon rex-icon-add"></i></a>


### PR DESCRIPTION
Da sind wohl mal i18n-Bezeichner angepasst worden und einer wurde vergessen. Das sieht im HTML so aus:

![grafik](https://user-images.githubusercontent.com/10065904/204019598-858fb3e5-098b-4eaa-89a5-8dac028ddf48.png)

Mit Korrektur durch diesen PR wird es 

<img width="732" alt="grafik" src="https://user-images.githubusercontent.com/10065904/204019747-13d4fac2-dd97-4193-ac8f-654783ec381e.png">

