### PR TITLE
Keys der Optionen fehlen

### DIFF
--- a/lib/yform/value/fieldset.php
+++ b/lib/yform/value/fieldset.php
@@ -9,7 +9,7 @@
 
 class rex_yform_value_fieldset extends rex_yform_value_abstract
 {
-    public static $fieldset_options = ['onlyclose', 'onlycloseall', 'onlyopen', 'closeandopen'];
+    public static $fieldset_options = ['onlyclose' => 'onlyclose', 'onlycloseall' => 'onlycloseall', 'onlyopen' => 'onlyopen', 'closeandopen' => 'closeandopen'];
 
     public function enterObject()
     {


### PR DESCRIPTION
Wenn die Keys nicht angegeben werden, verwendet Choice Zahlen als Indexe. Fieldset erwartet jedoch den Value-String.