### PR TITLE
Überschreiben der loadParams für das hidden field

### DIFF
--- a/lib/yform/value/hidden.php
+++ b/lib/yform/value/hidden.php
@@ -9,6 +9,16 @@
 
 class rex_yform_value_hidden extends rex_yform_value_abstract
 {
+    
+    public function loadParams(&$params, $elements = [])
+    {
+        $value = $elements[2] ?? null;
+        $elements[2] = '';
+        parent::loadParams($params, $elements);
+​
+        $this->setValue($value);
+    }
+    
     public function setValue($value)
     {
         if ('GET' == $this->getElement(3) && isset($_GET[$this->getElement(2)])) {


### PR DESCRIPTION
Durch die nachfolgende Änderung (in v4.0.3):
https://github.com/yakamara/redaxo_yform/commit/e22a536ebaca7d8adcbce4d53bb72636e76b447e Kann das ableitende hidden field nur noch strings als value aufnehmen, zuvor waren auch z.B. arrays möglich. Durch diesen PR wird die vorherige Funktionalität wieder hergestellt.