### PR TITLE
Überflüssige Zeile $id=.. entfernt

### DIFF
--- a/plugins/manager/ytemplates/bootstrap/value.be_manager_inline_relation.tpl.php
+++ b/plugins/manager/ytemplates/bootstrap/value.be_manager_inline_relation.tpl.php
@@ -13,8 +13,6 @@ $prioFieldName = $prioFieldName ?? '';
 
 $class_group = trim('form-group ' . $this->getHTMLClass()); // . ' ' . $this->getWarningClass()
 
-$id = sprintf('%u', crc32($this->params['form_name'])) . random_int(0, 10000) . $this->getId();
-
 $notice = [];
 if ('' != $this->getElement('notice')) {
     $notice[] = rex_i18n::translate($this->getElement('notice'), false);


### PR DESCRIPTION
Die Variable $id wird nirgends benutzt; auch nicht via `$this->parse('value.be_manager_inline_relation_form.tpl.php'...`. Scheint von einer alten Version über geblieben zu sein?

```php
$id = sprintf('%u', crc32($this->params['form_name'])) . random_int(0, 10000) . $this->getId();
```
![grafik](https://user-images.githubusercontent.com/10065904/212018791-fc155e27-d815-4ec1-b2ee-9c93176b1fa1.png)
