### PR TITLE
rex_yform_manager_collection: Methode current existiert in PHP 8 nicht mehr

### DIFF
--- a/plugins/manager/lib/yform/manager/collection.php
+++ b/plugins/manager/lib/yform/manager/collection.php
@@ -7,8 +7,6 @@
  *
  * @method rex_yform_manager_dataset offsetGet($offset)
  * @psalm-method T  offsetGet($offset)
- * @method rex_yform_manager_dataset current()
- * @psalm-method T current()
  * @method list<T> toArray()
  */
 class rex_yform_manager_collection extends \SplFixedArray

--- a/plugins/rest/lib/rest/route.php
+++ b/plugins/rest/lib/rest/route.php
@@ -200,7 +200,7 @@ class rex_yform_rest_route
                             echo $attribute;
                             $instances = $instance->getRelatedCollection($attribute);
                             if (count($instances) > 0) {
-                                $instance = $instances->current();
+                                $instance = $instances->first();
                             }
                             $fields = $this->getFields('get', $instance);
                             $instance = null;


### PR DESCRIPTION
`rex_yform_manager_collection` erbt von `SplFixedArray`. Und `SplFixedArray` hat früher `Iterator` implementiert, seit PHP 8.0 aber `IteratorAggregate`. Daher existiert seit PHP 8 die Methode `current` nicht mehr.

PR ungetestet!