### PR TITLE
CSV-Import: $id has to be an integer greater than 0, but "" given #1209

### DIFF
--- a/plugins/manager/pages/data_import.php
+++ b/plugins/manager/pages/data_import.php
@@ -170,7 +170,7 @@ if (1 == rex_request('send', 'int', 0)) {
                             break;
                         }
 
-                        if (null !== $idColumn && isset($line_array[$idColumn])) {
+                        if (null !== $idColumn && isset($line_array[$idColumn]) && $line_array[$idColumn] > 0) {
                             $id = $line_array[$idColumn];
                             $dataset = $this->table->getRawDataset((int) $id);
                         } else {


### PR DESCRIPTION
In If-else überprüfen ob ID im CSV leer oder 0 ist und in dem Fall Insert statt Update ausführen.
Damit klappen Daten-Imports mit neuen Inhalten (also ohne bereits existierende ID) auch wieder.