### PR TITLE
allow `varchar(196)` and `int` as `be_link` field definition

### DIFF
--- a/plugins/manager/lib/yform/value/be_link.php
+++ b/plugins/manager/lib/yform/value/be_link.php
@@ -41,7 +41,7 @@ class rex_yform_value_be_link extends rex_yform_value_abstract
             ],
             'description' => rex_i18n::msg('yform_values_be_link_description'),
             'formbuilder' => false,
-            'db_type' => ['text'],
+            'db_type' => ['text', 'varchar(191)', 'int'],
         ];
     }
 


### PR DESCRIPTION
text ist wohl in den meisten Fällen überdimensioniert, int für einzelne IDs (wenn nicht multiple) ideal.