### PR TITLE
Query um HAVING-Klausel erweitert

### DIFF
--- a/docs/04_yorm.md
+++ b/docs/04_yorm.md
@@ -482,11 +482,25 @@ echo $post->executeForm($yform)
   - resetWhere
   - setWhereOperator
   - where
+  - whereNot
+  - whereNull
+  - whereNotNull
+  - whereBetween
+  - whereNotBetween
   - whereNested
   - whereRaw
   - whereListContains
-
-Beispiel für whereListContains
+- Having
+  - resetHaving
+  - setHavingOperator
+  - having
+  - havingNot
+  - havingNull
+  - havingNotNull
+  - havingBetween
+  - havingNotBetween
+  - havingRaw
+  - havingListContainsBeispiel für whereListContains
 
 ```php
 // Entweder kann nach einem einzelnen Wert gesucht werden

--- a/docs/04_yorm.md
+++ b/docs/04_yorm.md
@@ -500,7 +500,9 @@ echo $post->executeForm($yform)
   - havingBetween
   - havingNotBetween
   - havingRaw
-  - havingListContainsBeispiel für whereListContains
+  - havingListContains
+  
+Beispiel für whereListContains
 
 ```php
 // Entweder kann nach einem einzelnen Wert gesucht werden

--- a/plugins/manager/lib/yform/manager/query.php
+++ b/plugins/manager/lib/yform/manager/query.php
@@ -513,7 +513,7 @@ class rex_yform_manager_query implements IteratorAggregate, Countable
      */
     public function havingRaw(string $having, array $params = []): self
     {
-        $this->having[] = $having;
+        $this->having[] = '('.$having.')';
         $this->params[self::PARAM_HAVING] = array_merge($this->params[self::PARAM_HAVING] ?? [], $params);
 
         return $this;


### PR DESCRIPTION
Auslöser des PR ist ein [Slack-Thread](https://friendsofredaxo.slack.com/archives/C1BAXLN2F/p1679900426442899).

Da HAVING im SELECT sowas wie WHERE im Gruppierungen ist, sind im Grunde die WHERE-bezogenen Teile dupliziert und im Namen um `having` erweitert. Die Teile werden an der passenden Stelle in die Query eingebaut.

Die `$this->params` werden als `$this->havingParams` separat geführt (sonst funktioniert `resetHaving()` nicht separat von `resetWhere()` und wäre sonst funktional ein Alias für `resetWhere` und vice versa. Entsprechend liefert getParams() nun das gemergte Array aus `$this->params` und `$this->havingParams`. Zur Unterscheidung haben havingParams `h` statt `p` als Marker.

`whereNested(..)` habe ich nicht übernommen. Das war mir zu heikel und der zwingende UseCase fiel mir nicht ein.