### PR TITLE
be_table holt über getValue die Werte, anstatt über Post im preValidateAction

### DIFF
--- a/plugins/manager/ytemplates/bootstrap/value.be_table-view.tpl.php
+++ b/plugins/manager/ytemplates/bootstrap/value.be_table-view.tpl.php
@@ -48,7 +48,7 @@ $main_id = $this->params['this']->getObjectparams('main_id');
                     /** @var rex_yform_value_abstract $field */
                     $field = $column['field'];
                     $field->params['form_output'] = [];
-                    $field->params['this']->setObjectparams('form_name', $this->getName() . '.' . $i);
+                    $field->params['this']->setObjectparams('form_name',$this->getParam('form_name').']['.$this->getId() . '][' . $i);
                     $field->params['this']->setObjectparams('form_ytemplate', $ytemplates);
                     $field->params['this']->setObjectparams('main_id', $main_id);
                     $field->params['this']->canEdit(false);

--- a/plugins/manager/ytemplates/bootstrap/value.be_table.tpl.php
+++ b/plugins/manager/ytemplates/bootstrap/value.be_table.tpl.php
@@ -49,7 +49,7 @@ $main_id = $this->params['this']->getObjectparams('main_id');
                     /** @var rex_yform_value_abstract $field */
                     $field = $column['field'];
                     $field->params['form_output'] = [];
-                    $field->params['this']->setObjectparams('form_name', $this->getName() . '.' . $i);
+                    $field->params['this']->setObjectparams('form_name',$this->getParam('form_name').']['.$this->getId() . '][' . $data_index);
                     $field->params['this']->setObjectparams('form_ytemplate', $ytemplates);
                     $field->params['this']->setObjectparams('main_id', $main_id);
                     $field->params['form_name'] = $field->getName();
@@ -61,7 +61,7 @@ $main_id = $this->params['this']->getObjectparams('main_id');
                         $field->setName($field->getElement('field'));
                     }
                     $field->setValue($rowData[$i] ?? '');
-                    $field->setId($data_index);
+                    $field->setId($i);
                     $field->enterObject();
                     $field_output = trim($field->params['form_output'][$field->getId()]);
 
@@ -113,7 +113,7 @@ $main_id = $this->params['this']->getObjectparams('main_id');
                         foreach ($columns as $i => $column) {
                             $field = $columns[$i]['field'];
                             $field->params['form_output'] = [];
-                            $field->params['this']->setObjectparams('form_name', $this->getName() . '.' . $i);
+                            $field->params['this']->setObjectparams('form_name',$this->getParam('form_name').']['.$this->getId() . '][{{FIELD_ID}}');
                             $field->params['this']->setObjectparams('form_ytemplate', $ytemplates);
                             $field->params['this']->setObjectparams('main_id', $main_id);
                             $field->params['form_name'] = $field->getName();
@@ -125,7 +125,7 @@ $main_id = $this->params['this']->getObjectparams('main_id');
                                 $field->setName($field->getElement('field'));
                             }
                             $field->setValue(null);
-                            $field->setId('{{FIELD_ID}}');
+                            $field->setId($i);
                             $field->enterObject();
                             $field_output = trim(strtr($field->params['form_output'][$field->getId()], ["\n" => '', "\r" => '', "'" => "\'"]));
 


### PR DESCRIPTION
Es gab ein Problem, wenn man das Feld be_table in Verbindung mit yorm verwendet hat. Wenn man über den Table Manager einen Wert geändert und übernehmen geklickt hat. Wenn auf der neuen Seite z.B. in einer boot.php o.ä. yorm verwendet wurde,  so wurde dieser Wert in alle mit dieser Abfrage stehenden Datensätze kopiert, da die POST-Parameter nicht Datensatz-spezifisch verwendet wurden. 
Ich habe nun die Datensätze in die "Post"-Struktur von yform gebracht, so dass die Daten einfach mit der yform getValue Methode geholt werden können. 
Das Format in der Datenbank wurde dabei nicht geändert.

