### PR TITLE
fix BE search filter for integers

### DIFF
--- a/lib/Field/value/integer.php
+++ b/lib/Field/value/integer.php
@@ -94,15 +94,15 @@ class rex_yform_value_integer extends rex_yform_value_abstract
         }
 
         // check for range with 'x..y' or 'x-y' patterns
-        if (preg_match('/^\s*(-?\d+)\s*\.\.\s*(-?\d+)\s*$/', $value, $match)) {
+        if (preg_match('/^\s*(-?\d+)\s*(?:\.\.|-)\s*(-?\d+)\s*$/', $value, $match)) {
             $match[1] = (int) $match[1];
             $match[2] = (int) $match[2];
             return $query->whereBetween($field, $match[1], $match[2]);
         }
 
         // check for comma separated values
-        if (preg_match('/^(-?\d+)(?:\s*,\s*(-?\d+))*$/', $match[2])) {
-            $values = array_map('intval', explode(',', $match[2]));
+        if (preg_match('/^(-?\d+)(?:\s*,\s*(-?\d+))*$/', $value)) {
+            $values = array_map('intval', explode(',', $value));
             return $query->whereListContains($field, $values);
         }
 


### PR DESCRIPTION
Bisher gibt es eine Warning:
"Undefined array key 2
Datei: src/addons/yform/lib/Field/value/integer.php:104",
wenn man in einer Yform Tabelle z.B. nach einer ID sucht.

In dem regex darüber wird behauptet man kann auch Ids im Muster "2-5" eingeben, aber das hat der regex nicht hergegeben.
Ist hier dann nachgerüstet.