### PR TITLE
Importer: $escape-Parameter bei fgetcsv explizit setzen wegen PHP 8.4

### DIFF
--- a/lib/manager/Importer.php
+++ b/lib/manager/Importer.php
@@ -157,7 +157,7 @@ class Importer
 
                 // out of transaction, because database not always supports transactions with alter table
                 $idColumn = null;
-                while (false !== ($line_array = fgetcsv($fp, 30384, $this->getDelimiter()))) {
+                while (false !== ($line_array = fgetcsv($fp, 30384, $this->getDelimiter(), '"', '\\'))) {
                     if (0 == count($fieldarray)) { /** @phpstan-ignore-line */
                         $fieldarray = $line_array;
                         $fieldarray = array_map('rex_string::normalize', $fieldarray);
@@ -255,7 +255,7 @@ class Importer
 
                 $sql_db = rex_sql::factory();
                 $sql_db->transactional(function () use ($fp, $idColumn, $fieldarray, &$counter, &$dcounter, &$ecounter, &$rcounter, &$icounter, &$errorcounter) {
-                    while (false !== ($line_array = fgetcsv($fp, 30384, $this->getDelimiter()))) {
+                    while (false !== ($line_array = fgetcsv($fp, 30384, $this->getDelimiter(), '"', '\\'))) {
                         if (!$line_array) {
                             break;
                         }


### PR DESCRIPTION
Warning:
fgetcsv(): the $escape parameter must be provided as its default value will change in src/addons/yform/lib/manager/Importer.php on line 258

PHP 8.4 deprecated den Default-Wert von fgetcsv()-$escape. 
Explizit als '\\' setzen (= identisches Verhalten zu vorher, nur Warning weg). 