### PR TITLE
Datumsfelder: NULL/leere Werte in der Listenansicht nicht an DateTime::createFromFormat() geben

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Version 5.0.3 - 17.07.2026
+--------------------------
+
+### Korrekturen
+
+* `rex_yform_value_date` und `rex_yform_value_datetime`: leere/`NULL`-Werte (nullable Spalten ohne Wert) werden in der Listenansicht jetzt als leer gerendert, statt `DateTime::createFromFormat()` mit `null` aufzurufen — das löste seit PHP 8.1 „Passing null to parameter #2 (\$datetime) of type string is deprecated" aus und ließ die Datensatz-Liste im Debug-Modus abbrechen.
+
 Version 5.0.2 - 12.05.2026
 --------------------------
 

--- a/lib/Field/value/date.php
+++ b/lib/Field/value/date.php
@@ -127,6 +127,11 @@ class rex_yform_value_date extends rex_yform_value_abstract
 
     public static function date_getFormattedDate($format, $date)
     {
+        // Empty/NULL values (nullable columns without a value) must not reach
+        // DateTime::createFromFormat() — passing null is deprecated since PHP 8.1.
+        if (null === $date || '' === $date) {
+            return '';
+        }
         $format = (in_array($format, self::VALUE_DATE_FORMATS, true)) ? $format : self::VALUE_DATE_DEFAULT_FORMAT;
         $DTdate = DateTime::createFromFormat('Y-m-d', $date);
         return (!$DTdate || $date != $DTdate->format('Y-m-d')) ? '[' . $date . ']' : $DTdate->format($format);

--- a/lib/Field/value/datetime.php
+++ b/lib/Field/value/datetime.php
@@ -137,6 +137,11 @@ class rex_yform_value_datetime extends rex_yform_value_abstract
 
     public static function datetime_getFormattedDatetime($format, $date)
     {
+        // Empty/NULL values (nullable columns without a value) must not reach
+        // DateTime::createFromFormat() — passing null is deprecated since PHP 8.1.
+        if (null === $date || '' === $date) {
+            return '';
+        }
         $format = (in_array($format, self::VALUE_DATETIME_FORMATS, true)) ? $format : self::VALUE_DATETIME_DEFAULT_FORMAT;
         $DTdate = DateTime::createFromFormat('Y-m-d H:i:s', $date);
         return (!$date || !$DTdate || $date != $DTdate->format('Y-m-d H:i:s')) ? '[' . $date . ']' : $DTdate->format($format);


### PR DESCRIPTION
## Problem

Beim Öffnen der Datensatz-Liste einer YForm-Tabelle mit einem `date`- oder `datetime`-Feld, dessen (nullable) Spalte keinen Wert hat, bricht die Liste im Debug-Modus ab:

```
DateTime::createFromFormat(): Passing null to parameter #2 ($datetime) of type string is deprecated
  .../lib/Field/value/date.php:131
```

`rex_yform_value_date::date_getFormattedDate()` bzw. `rex_yform_value_datetime::datetime_getFormattedDatetime()` rufen `DateTime::createFromFormat()` auf, **bevor** sie den Wert auf leer/`NULL` prüfen. Bei nullable Spalten (z. B. optionale Termin- oder Workflow-Daten, die erst später gesetzt werden) ist der Wert `NULL` → Deprecation seit PHP 8.1, und im Debug-Modus wird daraus ein Abbruch der Listenansicht.

## Fix

Früh-Return für leere/`NULL`-Werte, bevor `createFromFormat()` aufgerufen wird — die Zelle wird dann leer gerendert (statt `[]`). Gültige Daten und die `[…]`-Markierung für echte Fehlwerte verhalten sich unverändert.

## Verifikation

`getListValue()` über beide Feldtypen mit `null` / `''` / gültigem Wert / Müll:

| Eingabe | vorher | nachher |
|---|---|---|
| `null` | Deprecation → `[]` | `` (leer) |
| `''` | `[]` | `` (leer) |
| `2026-06-05` | `05.06.2026` | `05.06.2026` |
| `garbage` | `[garbage]` | `[garbage]` |

(analog für `datetime`)

---

*Hinweis: Versionsnummer und Datum im CHANGELOG (`5.0.3` / `17.07.2026`) sind provisorisch — bitte beim Release anpassen.*
