### PR TITLE
Fix: `Undefined array key "_csrf_token"` in REX_YFORM_TABLE_DATA-Widgets

### DIFF
--- a/lib/RexVar/var_yform_dataset.php
+++ b/lib/RexVar/var_yform_dataset.php
@@ -45,6 +45,7 @@ class rex_var_yform_table_data extends rex_var
                 'table' => $table,
                 'fieldName' => $fieldName,
             ];
+            $args += rex_csrf_token::factory($table->getCSRFKey())->getUrlParams();
 
             if ($this->hasArg('multiple') && $this->getArg('multiple')) {
                 $options = [];


### PR DESCRIPTION
### Problem

Sobald ein Modul-Input `REX_YFORM_TABLE_DATA[... widget=1]` verwendet, bricht das Anlegen bzw. Bearbeiten eines Slices im Backend ab:

```
ErrorException: Undefined array key "_csrf_token"
in lib/RexVar/var_yform_dataset.php:137
#25 rex_var_yform_table_data:getMultipleWidget (var_yform_dataset.php:65)
#24 rex_var_yform_table_data:getOutput (core/lib/var/var.php:374)
...
#18 rex_article_content_editor:addSlice
```

Mit `throw_always_exception` im Debug-Flag (typisch auf Live-Systemen) wird daraus eine ErrorException und die Seite ist nicht mehr bedienbar. Ohne das Flag bleibt es eine Warning – dann wird das Widget aber mit leerem `data-csrf_token` gerendert (siehe „Nebeneffekt" unten).

### Reproduktion

1. YForm-Tabelle anlegen (z. B. `rex_beispiel`)
2. Modul-Input: `REX_YFORM_TABLE_DATA[id=1 table="rex_beispiel" widget=1 multiple=1]`
3. Im Backend einen Slice mit diesem Modul anlegen

Tritt bei `multiple=1` (Zeile 137, `getMultipleWidget()`) und bei `multiple=0` (Zeile 173, `getSingleWidget()`) gleichermaßen auf.

### Ursache

`getSingleWidget()` und `getMultipleWidget()` lesen `$args['_csrf_token']` unbedingt aus, um es als `data-csrf_token` ans Widget zu schreiben.

Der Aufrufpfad über `ytemplates/bootstrap/value.be_manager_relation.tpl.php` (Zeilen 74–87) füllt den Key korrekt:

```php
$_csrf_key = rex_yform_manager_table::get($this->rCSRFKey();
$args += rex_csrf_token::factory($_csrf_key)->getUrlParams();
```

Der Aufrufpfad über `rex_var_yform_table_data::getOutput()` baut `$args` dagegen nur mit `link`, `table` und `fieldName` – der Token fehlt.

### Fix

`getOutput()` setzt den Token analog zum Template, mit dem CSRF-Key der Ziel-Tabelle (`$table->getCSRFKey()` → `table_field-<tabelle>`):

```diff
             $args = [
                 'link' => 'index.php?page=yform/m . $table->getTableName(),
                 'table' => $table,
                 'fieldName' => $fieldName,
             ];
+            $args += rex_csrf_token::factory($table->getCSRFKey())->getUrlParams();
```

Eine Zeile, deckt beide Widget-Varianten ab, weil sie vor der `multiple`-Verzweigung greift. Alternativ hätte man die Widget-Methoden mit `$args['_csrf_token'] ?? ''` absichern können – das würde den Fehler aber nur verstecken und weiterhin defekte Popup-Links erzeugen.

### Nebeneffekt

`assets/widget.js` (Zeilen 48 und 72) hängt `data-csrf_token` an die `data_edit`-URL, wenn man „Datensatz wählen / anlegen / bearbeiten" klickt. Geprüft wird der Token in `lib/manager/manager.php` gegen `$this->table->getCSRFKey()` – also genau den Key, der hier nun verwendet wird. Der Fix behebt damit nicht nur die Exception, sondern auch, dass diese Popup-Aufrufe ohne bzw. mit leerem Token an der CSRF-Prüfung scheitern.

### Betroffene Version

Gefunden in 5.0.2.